### PR TITLE
Delete an unused AppMetadata instance in SignView.

### DIFF
--- a/Example/metamask-ios-sdk/SignView.swift
+++ b/Example/metamask-ios-sdk/SignView.swift
@@ -22,7 +22,6 @@ struct SignView: View {
     
     private let signButtonTitle = "Sign"
     private let connectAndSignButtonTitle = "Connect & Sign"
-    private static let appMetadata = AppMetadata(name: "Dub Dapp", url: "https://dubdapp.com")
 
     var body: some View {
         GeometryReader { geometry in


### PR DESCRIPTION
## Description of the change:
There is an unused static instance of AppMetadata in SignView. 
Since it might cause confusion, I kindly request to delete that property. 