### PR TITLE
Fix Swift Language Version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,5 +32,5 @@ let package = Package(
                 name: "Ecies",
                 path: "Sources/metamask-ios-sdk/Frameworks/Ecies.xcframework"),
     ],
-    swiftLanguageVersions: [.v5_5]
+    swiftLanguageVersions: [.version("5.5")]
 )


### PR DESCRIPTION
In XCode 15.2 I get the following Error:
`Type 'Array<SwiftVersion>.ArrayLiteralElement' (aka 'SwiftVersion') has no member 'v5_5'`

With the change in Line 35 in the Package.swift-File the build works again.
`swiftLanguageVersions: [.version("5.5")]`
 
After the change, I can also add the package to an iOS 17.2 project again. Currently, when I try to add the package to my project, it aborts with the following message:
```
Invalid manifest (compiled with: ["/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc", "-vfsoverlay", "/var/folders/hd/7hmpy7n526sf6cbxj5r060yh0000gn/T/TemporaryDirectory.ZXirsl/vfs.yaml", "-L", "/Applications/Xcode.app/Contents/SharedFrameworks/SwiftPM.framework/SharedSupport/ManifestAPI", "-lPackageDescription", "-Xlinker", "-rpath", "-Xlinker", "/Applications/Xcode.app/Contents/SharedFrameworks/SwiftPM.framework/SharedSupport/ManifestAPI", "-target", "arm64-apple-macos13.0", "-sdk", "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk", "-swift-version", "5", "-I", "/Applications/Xcode.app/Contents/SharedFrameworks/SwiftPM.framework/SharedSupport/ManifestAPI", "-sdk", "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk", "-package-description-version", "5.7.0", "-Xfrontend", "-serialize-diagnostics-path", "-Xfrontend", "/Users/admin/Library/Caches/org.swift.swiftpm/manifests/ManifestLoading/metamask-ios-sdk.dia", "/Package.swift", "-disallow-use-new-driver", "-o", "/var/folders/hd/7hmpy7n526sf6cbxj5r060yh0000gn/T/TemporaryDirectory.HCXUXE/metamask-ios-sdk-manifest"])
```

