### PR TITLE
explicit self in closure

### DIFF
--- a/Sources/metamask-ios-sdk/Classes/Communication/Client.swift
+++ b/Sources/metamask-ios-sdk/Classes/Communication/Client.swift
@@ -232,7 +232,7 @@ private extension Client {
             guard let self = self else { return }
             Logging.log("SDK disconnected")
 
-            track(event: .disconnected)
+            self.track(event: .disconnected)
 
             // for debug purposes only
             NotificationCenter.default.post(
@@ -241,7 +241,7 @@ private extension Client {
                 userInfo: ["value": "Clients Disconnected"]
             )
 
-            isReady = false
+            self.isReady = false
         }
     }
 }


### PR DESCRIPTION
Since swift5.8, inside closure, guard let self = else else {return} you don't need to do self.
This is effective as of Xcode 14.3.
However, I have to use Xcode 14.3 or earlier due to my work environment.
So I get build errors in code without self.
Please put 'self' inside the closure

cc https://www.hackingwithswift.com/swift/5.8/implicit-self-weak-capture