### PR TITLE
Send deeplinking connect result

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Alternatively, you can add the URL directly in your project's package file:
 dependencies: [
     .package(
         url: "https://github.com/MetaMask/metamask-ios-sdk",
-        from: "0.6.1"
+        from: "0.6.2"
     )
 ]
 ```

--- a/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
+++ b/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
@@ -662,6 +662,7 @@ public class Ethereum {
                 let accounts = event["accounts"] as? [String],
                 let selectedAddress = accounts.first {
                 updateAccount(selectedAddress)
+                sendResult(selectedAddress, id: Ethereum.CONNECTION_ID)
             }
             return
         }

--- a/metamask-ios-sdk.podspec
+++ b/metamask-ios-sdk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'metamask-ios-sdk'
-  s.version          = '0.6.1'
+  s.version          = '0.6.2'
   s.summary          = 'Enable users to easily connect with their MetaMask Mobile wallet.'
   s.swift_version    = '5.5'
 


### PR DESCRIPTION
When connecting via deeplinking, the connect result wasn't being sent because the response json structure is a bit different and while it updated the chainId and selected address, it was not resolving the publisher to return a result