### PR TITLE
feat: React Native SDK Integration Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Alternatively, you can add the URL directly in your project's package file:
 dependencies: [
     .package(
         url: "https://github.com/MetaMask/metamask-ios-sdk",
-        from: "0.6.2"
+        from: "0.6.3"
     )
 ]
 ```

--- a/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
+++ b/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
@@ -168,6 +168,7 @@ public class Ethereum {
         case .socket:
             commClient.connect(with: nil)
             
+            // React Native SDK has request params as Data
             if let paramsData = req.params as? Data {
                 let reqJson = String(data: paramsData, encoding: .utf8)?.trimEscapingChars() ?? ""
                 let requestItem: EthereumRequest = EthereumRequest(
@@ -191,6 +192,7 @@ public class Ethereum {
             submittedRequests[connectWithRequest.id] = submittedRequest
             let publisher = submittedRequests[connectWithRequest.id]?.publisher
             
+            // React Native SDK has request params as Data
             if let paramsData = req.params as? Data {
                 do {
                     let params = try JSONSerialization.jsonObject(with: paramsData, options: [])

--- a/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
+++ b/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
@@ -52,8 +52,12 @@ public class Ethereum {
         return ethereum
     }
     
-    func updateTransportLayer(_ transport: Transport) {
+    public var transport: Transport = .socket
+    
+    @discardableResult
+    func updateTransportLayer(_ transport: Transport) -> Ethereum {
         disconnect()
+        self.transport = transport
         
         switch transport {
         case .deeplinking(let dappScheme):
@@ -65,6 +69,7 @@ public class Ethereum {
         
         commClient.trackEvent = trackEvent
         commClient.handleResponse = handleMessage
+        return self
     }
     
     private func trackEvent(event: Event, parameters: [String: Any]) {
@@ -159,18 +164,68 @@ public class Ethereum {
         )
         connected = true
         
-        if commClient is SocketClient {
+        switch transport {
+        case .socket:
             commClient.connect(with: nil)
-            return request(connectWithRequest)
+            
+            if let paramsData = req.params as? Data {
+                let reqJson = String(data: paramsData, encoding: .utf8)?.trimEscapingChars() ?? ""
+                let requestItem: EthereumRequest = EthereumRequest(
+                    id: req.id,
+                    method: req.method,
+                    params: reqJson
+                )
+                
+                let connectWithParams = [requestItem]
+                let connectRequest = EthereumRequest(
+                    id: connectWithRequest.id,
+                    method: connectWithRequest.method,
+                    params: connectWithParams
+                )
+                return request(connectRequest)
+            } else {
+                return request(connectWithRequest)
+            }
+        case .deeplinking(_):
+            let submittedRequest = SubmittedRequest(method: connectWithRequest.method)
+            submittedRequests[connectWithRequest.id] = submittedRequest
+            let publisher = submittedRequests[connectWithRequest.id]?.publisher
+            
+            if let paramsData = req.params as? Data {
+                do {
+                    let params = try JSONSerialization.jsonObject(with: paramsData, options: [])
+                    
+                    let requestDict: [String: Any] = [
+                        "id": req.id,
+                        "method": req.method,
+                        "params": params
+                        ]
+                    
+                    let jsonData = try JSONSerialization.data(withJSONObject: requestDict)
+                    let jsonParams = try JSONSerialization.jsonObject(with: jsonData, options: [])
+
+                    let connectWithParams = [jsonParams]
+                    
+                    let connectWithDict: [String: Any] = [
+                        "id": connectWithRequest.id,
+                        "method": connectWithRequest.method,
+                        "params": connectWithParams
+                        ]
+                    
+                    let connectWithData = try JSONSerialization.data(withJSONObject: connectWithDict)
+                    
+                    let connectWithJson = String(data: connectWithData, encoding: .utf8)?.trimEscapingChars() ?? ""
+                    
+                    commClient.connect(with: connectWithJson)
+                } catch {
+                    Logging.error("Ethereum:: error: \(error.localizedDescription)")
+                }
+            } else {
+                let requestJson = connectWithRequest.toJsonString() ?? ""
+                commClient.connect(with: requestJson)
+            }
+            return publisher
         }
-        
-        let submittedRequest = SubmittedRequest(method: connectWithRequest.method)
-        submittedRequests[connectWithRequest.id] = submittedRequest
-        let publisher = submittedRequests[connectWithRequest.id]?.publisher
-        let requestJson = connectWithRequest.toJsonString() ?? ""
-        
-        commClient.connect(with: requestJson)
-        return publisher
     }
     
     func connectWith<T: CodableData>(_ req: EthereumRequest<T>) async -> Result<String, RequestError> {
@@ -253,7 +308,7 @@ public class Ethereum {
         await ethereumRequest(method: .ethGetTransactionCount, params: [address, tagOrblockNumber])
     }
     
-    func addEthereumChain(chainId: String, 
+    func addEthereumChain(chainId: String,
                           chainName: String,
                           rpcUrls: [String],
                           iconUrls: [String]?,
@@ -338,8 +393,32 @@ public class Ethereum {
                 "from": "mobile",
                 "method": request.method
             ])
-            if commClient is SocketClient {
-                (commClient as? SocketClient)?.sendMessage(request, encrypt: true)
+            
+            switch transport {
+            case .socket:
+                // React Native SDK has request params as Data
+                if let paramsData = request.params as? Data {
+                    do {
+                        let params = try JSONSerialization.jsonObject(with: paramsData, options: [])
+                        
+                        let requestDict: [String: Any] = [
+                            "id": request.id,
+                            "method": request.method,
+                            "params": params
+                            ]
+                        
+                        let requestData = try JSONSerialization.data(withJSONObject: requestDict)
+                        
+                        
+                        let requestJson = String(data: requestData, encoding: .utf8)?.trimEscapingChars() ?? ""
+                        
+                        commClient.sendMessage(requestJson, encrypt: true)
+                    } catch {
+                        Logging.error("Ethereum:: error: \(error.localizedDescription)")
+                    }
+                } else {
+                    (commClient as? SocketClient)?.sendMessage(request, encrypt: true)
+                }
                 
                 let authorise = EthereumMethod.requiresAuthorisation(request.methodType)
                 let skipAuthorisation = request.methodType == .ethRequestAccounts && !account.isEmpty
@@ -347,13 +426,35 @@ public class Ethereum {
                 if authorise && !skipAuthorisation {
                     (commClient as? SocketClient)?.requestAuthorisation()
                 }
-            } else {
-                guard let requestJson = request.toJsonString() else {
-                    Logging.error("Ethereum:: could not convert request to JSON: \(request)")
-                    return
-                } 
                 
-                commClient.sendMessage(requestJson, encrypt: true)
+            case .deeplinking(_):
+                // React Native SDK has request params as Data
+                if let paramsData = request.params as? Data {
+                    do {
+                        let params = try JSONSerialization.jsonObject(with: paramsData, options: [])
+                        
+                        let requestDict: [String: Any] = [
+                            "id": request.id,
+                            "method": request.method,
+                            "params": params
+                            ]
+                        
+                        let jsonData = try JSONSerialization.data(withJSONObject: requestDict)
+                        let requestJson = String(data: jsonData, encoding: .utf8)?.trimEscapingChars() ?? ""
+                        
+                        commClient.sendMessage(requestJson, encrypt: true)
+                    } catch {
+                        Logging.error("Ethereum:: error: \(error.localizedDescription)")
+                        return
+                    }
+                } else {
+                    guard let requestJson = request.toJsonString() else {
+                        Logging.error("Ethereum:: could not convert request to JSON: \(request)")
+                            return
+                        }
+                                    
+                    commClient.sendMessage(requestJson, encrypt: true)
+                }
             }
         }
     }
@@ -465,23 +566,71 @@ public class Ethereum {
         }
     }
     
-    func batchRequest<T: CodableData>(_ params: [EthereumRequest<T>]) async -> Result<[String], RequestError> {
-        let batchRequest = EthereumRequest(
-            method: EthereumMethod.metamaskBatch.rawValue,
-            params: params)
-
-        return await withCheckedContinuation { continuation in
-            request(batchRequest)?
-                .sink(receiveCompletion: { completion in
-                    switch completion {
-                    case .finished:
-                        continuation.resume(returning: .success([]))
-                    case .failure(let error):
-                        continuation.resume(returning: .failure(error))
+    func batchRequest<T: CodableData>(_ requests: [EthereumRequest<T>]) async -> Result<[String], RequestError> {
+        
+        // React Native SDK has request params as Data
+        if let _ = requests.first?.params as? Data {
+            var requestDicts: [[String: Any]] = []
+            
+            for request in requests {
+                if let paramData = request.params as? Data {
+                    do {
+                        let requestParams = try JSONSerialization.jsonObject(with: paramData, options: [])
+                        
+                        let dict: [String: Any] = [
+                            "id": request.id,
+                            "method": request.method,
+                            "params": requestParams
+                        ]
+                        requestDicts.append(dict)
+                    } catch {
+                        Logging.error("Ethereum:: error: \(error.localizedDescription)")
+                        return .failure(RequestError(from: ["message": error.localizedDescription]))
                     }
-                }, receiveValue: { result in
-                    continuation.resume(returning: .success(result as? [String] ?? []))
-                }).store(in: &cancellables)
+                }
+            }
+            
+            do {
+                let jsonData = try JSONSerialization.data(withJSONObject: requestDicts)
+                let batchReq = EthereumRequest(
+                    method: EthereumMethod.metamaskBatch.rawValue,
+                    params: jsonData)
+                
+                return await withCheckedContinuation { continuation in
+                    request(batchReq)?
+                        .sink(receiveCompletion: { completion in
+                            switch completion {
+                            case .finished:
+                                continuation.resume(returning: .success([]))
+                            case .failure(let error):
+                                continuation.resume(returning: .failure(error))
+                            }
+                        }, receiveValue: { result in
+                            continuation.resume(returning: .success(result as? [String] ?? []))
+                        }).store(in: &cancellables)
+                }
+            } catch {
+                Logging.error("Ethereum:: error: \(error.localizedDescription)")
+                return .failure(RequestError(from: ["message": error.localizedDescription]))
+            }
+        } else {
+            let batchRequest = EthereumRequest(
+                method: EthereumMethod.metamaskBatch.rawValue,
+                params: requests)
+
+            return await withCheckedContinuation { continuation in
+                request(batchRequest)?
+                    .sink(receiveCompletion: { completion in
+                        switch completion {
+                        case .finished:
+                            continuation.resume(returning: .success([]))
+                        case .failure(let error):
+                            continuation.resume(returning: .failure(error))
+                        }
+                    }, receiveValue: { result in
+                        continuation.resume(returning: .success(result as? [String] ?? []))
+                    }).store(in: &cancellables)
+            }
         }
     }
     

--- a/Sources/metamask-ios-sdk/Classes/SDK/Dependencies.swift
+++ b/Sources/metamask-ios-sdk/Classes/SDK/Dependencies.swift
@@ -25,7 +25,7 @@ public final class Dependencies {
         
         return Ethereum.shared(commClient: client) { event, parameters in
             self.trackEvent(event, parameters: parameters)
-        }
+        }.updateTransportLayer(transport)
     }
     
     public lazy var keyExchange: KeyExchange = KeyExchange()

--- a/Sources/metamask-ios-sdk/Classes/SDK/MetaMaskSDK.swift
+++ b/Sources/metamask-ios-sdk/Classes/SDK/MetaMaskSDK.swift
@@ -32,6 +32,8 @@ public class MetaMaskSDK: ObservableObject {
         }
     }
     
+    public var transport: Transport
+    
     public var networkUrl: String {
         get {
             (ethereum.commClient as? SocketClient)?.networkUrl ?? ""
@@ -56,6 +58,7 @@ public class MetaMaskSDK: ObservableObject {
 
     private init(appMetadata: AppMetadata, transport: Transport, enableDebug: Bool, sdkOptions: SDKOptions?) {
         self.ethereum = Dependencies.shared.ethereum(transport: transport)
+        self.transport = transport
         self.ethereum.delegate = self
         self.ethereum.sdkOptions = sdkOptions
         self.ethereum.updateMetadata(appMetadata)
@@ -67,7 +70,7 @@ public class MetaMaskSDK: ObservableObject {
         (ethereum.commClient as? DeeplinkClient)?.handleUrl(url)
     }
     
-    public static func shared(_ appMetadata: AppMetadata, 
+    public static func shared(_ appMetadata: AppMetadata,
                               transport: Transport = .socket,
                               enableDebug: Bool = true,
                               sdkOptions: SDKOptions?) -> MetaMaskSDK {

--- a/metamask-ios-sdk.podspec
+++ b/metamask-ios-sdk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'metamask-ios-sdk'
-  s.version          = '0.6.2'
+  s.version          = '0.6.3'
   s.summary          = 'Enable users to easily connect with their MetaMask Mobile wallet.'
   s.swift_version    = '5.5'
 


### PR DESCRIPTION
This PR adds support for React Native (RN) SDK that wraps the iOS Native SDK so that it can be used in RN apps. 

Because of the heavily protocol & generics - based architecture of this SDK and the limitations in conveniently representing these in Objective C - which the RN bridge interfaces with directly, the RN wrapper sends information rpc parameters as `Data` blobs instead of defined model types. This change adds support to handle data rpc requests.