### PR TITLE
fix: handle complex request types

### DIFF
--- a/Example/metamask-ios-sdk/ConnectView.swift
+++ b/Example/metamask-ios-sdk/ConnectView.swift
@@ -15,7 +15,7 @@ private let DAPP_SCHEME = "dubdapp"
 
 @MainActor
 struct ConnectView: View {
-    @State var selectedTransport: Transport = .deeplinking(dappScheme: DAPP_SCHEME)
+    @State var selectedTransport: Transport = .socket//.deeplinking(dappScheme: DAPP_SCHEME)
     @State private var dappScheme: String = DAPP_SCHEME
 
     private static let appMetadata = AppMetadata(
@@ -27,7 +27,7 @@ struct ConnectView: View {
     // We recommend adding support for Infura API for read-only RPCs (direct calls) via SDKOptions
     @ObservedObject var metaMaskSDK = MetaMaskSDK.shared(
                     appMetadata,
-                    transport: .deeplinking(dappScheme: DAPP_SCHEME),
+                    transport: .socket,//.deeplinking(dappScheme: DAPP_SCHEME),
                     sdkOptions: nil // SDKOptions(infuraAPIKey: "####")
                 )
 
@@ -223,11 +223,11 @@ struct ConnectView: View {
         showProgressView = false
         
         switch result {
+        case .success(_):
+            status = "Online"
         case let .failure(error):
             errorMessage = error.localizedDescription
             showError = true
-        default:
-            break
         }
     }
 }

--- a/Example/metamask-ios-sdk/ConnectView.swift
+++ b/Example/metamask-ios-sdk/ConnectView.swift
@@ -15,7 +15,7 @@ private let DAPP_SCHEME = "dubdapp"
 
 @MainActor
 struct ConnectView: View {
-    @State var selectedTransport: Transport = .socket//.deeplinking(dappScheme: DAPP_SCHEME)
+    @State var selectedTransport: Transport = .deeplinking(dappScheme: DAPP_SCHEME)
     @State private var dappScheme: String = DAPP_SCHEME
 
     private static let appMetadata = AppMetadata(
@@ -27,7 +27,7 @@ struct ConnectView: View {
     // We recommend adding support for Infura API for read-only RPCs (direct calls) via SDKOptions
     @ObservedObject var metaMaskSDK = MetaMaskSDK.shared(
                     appMetadata,
-                    transport: .socket,//.deeplinking(dappScheme: DAPP_SCHEME),
+                    transport: .deeplinking(dappScheme: DAPP_SCHEME),
                     sdkOptions: nil // SDKOptions(infuraAPIKey: "####")
                 )
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Alternatively, you can add the URL directly in your project's package file:
 dependencies: [
     .package(
         url: "https://github.com/MetaMask/metamask-ios-sdk",
-        from: "0.6.3"
+        from: "0.6.4"
     )
 ]
 ```

--- a/Sources/metamask-ios-sdk/Classes/CommunicationLayer/DeeplinkCommLayer/String.swift
+++ b/Sources/metamask-ios-sdk/Classes/CommunicationLayer/DeeplinkCommLayer/String.swift
@@ -14,3 +14,36 @@ extension String {
         return unescapedString
     }
 }
+
+func json(from value: Any) -> String? {
+    // Recursive function to decode nested JSON strings
+    func decodeNestedJson(_ value: Any) -> Any {
+        if let arrayValue = value as? [Any] {
+            // If it's an array, recursively decode each element
+            return arrayValue.map { decodeNestedJson($0) }
+        } else if let dictValue = value as? [String: Any] {
+            // If it's a dictionary, recursively decode each value
+            var decodedDict = [String: Any]()
+            for (key, value) in dictValue {
+                decodedDict[key] = decodeNestedJson(value)
+            }
+            return decodedDict
+        } else {
+            // If it's neither a string, array, nor dictionary, return the value as is
+            return value
+        }
+    }
+    
+    // Decode any nested JSON strings recursively in the input dictionary
+    let decodedJsonObject = decodeNestedJson(value)
+    
+    // Step 3: Convert the cleaned dictionary back to a JSON string
+    guard let cleanedJsonData = try? JSONSerialization.data(withJSONObject: decodedJsonObject, options: []),
+          let cleanedJsonString = String(data: cleanedJsonData, encoding: .utf8) else {
+        Logging.error("Failed to serialize cleaned JSON dictionary")
+        return nil
+    }
+    
+    return cleanedJsonString
+}
+

--- a/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
+++ b/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
@@ -168,6 +168,7 @@ public class Ethereum {
         case .socket:
             commClient.connect(with: nil)
             
+            // React Native SDK has request params as Data
             if let paramsData = req.params as? Data {
                 let reqJson = String(data: paramsData, encoding: .utf8)?.trimEscapingChars() ?? ""
                 let requestItem: EthereumRequest = EthereumRequest(
@@ -191,6 +192,7 @@ public class Ethereum {
             submittedRequests[connectWithRequest.id] = submittedRequest
             let publisher = submittedRequests[connectWithRequest.id]?.publisher
             
+            // React Native SDK has request params as Data
             if let paramsData = req.params as? Data {
                 do {
                     let params = try JSONSerialization.jsonObject(with: paramsData, options: [])
@@ -224,10 +226,6 @@ public class Ethereum {
             }
             return publisher
         }
-    }
-    
-    private func handleConnectWithRequest<T: CodableData>(_ req: EthereumRequest<T>) {
-        
     }
     
     func connectWith<T: CodableData>(_ req: EthereumRequest<T>) async -> Result<String, RequestError> {

--- a/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
+++ b/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
@@ -168,7 +168,6 @@ public class Ethereum {
         case .socket:
             commClient.connect(with: nil)
             
-            // React Native SDK has request params as Data
             if let paramsData = req.params as? Data {
                 let reqJson = String(data: paramsData, encoding: .utf8)?.trimEscapingChars() ?? ""
                 let requestItem: EthereumRequest = EthereumRequest(
@@ -192,7 +191,6 @@ public class Ethereum {
             submittedRequests[connectWithRequest.id] = submittedRequest
             let publisher = submittedRequests[connectWithRequest.id]?.publisher
             
-            // React Native SDK has request params as Data
             if let paramsData = req.params as? Data {
                 do {
                     let params = try JSONSerialization.jsonObject(with: paramsData, options: [])
@@ -214,9 +212,7 @@ public class Ethereum {
                         "params": connectWithParams
                         ]
                     
-                    let connectWithData = try JSONSerialization.data(withJSONObject: connectWithDict)
-                    
-                    let connectWithJson = String(data: connectWithData, encoding: .utf8)?.trimEscapingChars() ?? ""
+                    let connectWithJson = json(from: connectWithDict) ?? ""
                     
                     commClient.connect(with: connectWithJson)
                 } catch {
@@ -228,6 +224,10 @@ public class Ethereum {
             }
             return publisher
         }
+    }
+    
+    private func handleConnectWithRequest<T: CodableData>(_ req: EthereumRequest<T>) {
+        
     }
     
     func connectWith<T: CodableData>(_ req: EthereumRequest<T>) async -> Result<String, RequestError> {
@@ -409,10 +409,7 @@ public class Ethereum {
                             "params": params
                             ]
                         
-                        let requestData = try JSONSerialization.data(withJSONObject: requestDict)
-                        
-                        
-                        let requestJson = String(data: requestData, encoding: .utf8)?.trimEscapingChars() ?? ""
+                        let requestJson = json(from: requestDict) ?? ""
                         
                         commClient.sendMessage(requestJson, encrypt: true)
                     } catch {
@@ -441,8 +438,7 @@ public class Ethereum {
                             "params": params
                             ]
                         
-                        let jsonData = try JSONSerialization.data(withJSONObject: requestDict)
-                        let requestJson = String(data: jsonData, encoding: .utf8)?.trimEscapingChars() ?? ""
+                        let requestJson = json(from: requestDict) ?? ""
                         
                         commClient.sendMessage(requestJson, encrypt: true)
                     } catch {

--- a/metamask-ios-sdk.podspec
+++ b/metamask-ios-sdk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'metamask-ios-sdk'
-  s.version          = '0.6.3'
+  s.version          = '0.6.4'
   s.summary          = 'Enable users to easily connect with their MetaMask Mobile wallet.'
   s.swift_version    = '5.5'
 


### PR DESCRIPTION
Requests with complex parameters eg nested json structures like in `eth_signTypedData_v4` wasn't being handled well when made from react native SDK wrapper. As result `eth_signTypedData_v4` wasn't working on RN Android. This PR addresses that.