### PR TITLE
feat: Add context with address and chain id

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Alternatively, you can add the URL directly in your project's package file:
 dependencies: [
     .package(
         url: "https://github.com/MetaMask/metamask-ios-sdk",
-        from: "0.6.4"
+        from: "0.6.5"
     )
 ]
 ```

--- a/Sources/metamask-ios-sdk/Classes/CommunicationLayer/CommClient.swift
+++ b/Sources/metamask-ios-sdk/Classes/CommunicationLayer/CommClient.swift
@@ -18,7 +18,7 @@ public protocol CommClient {
     func disconnect()
     func clearSession()
     func addRequest(_ job: @escaping RequestJob)
-    func sendMessage(_ message: String, encrypt: Bool)
+    func sendMessage(_ message: String, encrypt: Bool, options: [String: String])
 }
 
 public extension CommClient {

--- a/Sources/metamask-ios-sdk/Classes/CommunicationLayer/DeeplinkCommLayer/DeeplinkClient.swift
+++ b/Sources/metamask-ios-sdk/Classes/CommunicationLayer/DeeplinkCommLayer/DeeplinkClient.swift
@@ -75,7 +75,7 @@ public class DeeplinkClient: CommClient {
         deeplinkManager.handleUrl(url)
     }
     
-    func sendMessage(_ deeplink: Deeplink) {
+    func sendMessage(_ deeplink: Deeplink, options: [String: String]) {
         switch deeplink {
         case .connect(_, let channelId, let request):
             let originatorInfo = originatorInfo().toJsonString()?.base64Encode() ?? ""
@@ -85,7 +85,9 @@ public class DeeplinkClient: CommClient {
             }
             sendMessage(message)
         case .mmsdk(let message, _, let channelId):
-            let message = "mmsdk?scheme=\(dappScheme)&message=\(message)&channelId=\(channelId ?? "")"
+            let account = options["account"] ?? ""
+            let chainId = options["chainId"] ?? ""
+            let message = "mmsdk?scheme=\(dappScheme)&message=\(message)&channelId=\(channelId ?? "")&account=\(account)@\(chainId)"
             Logging.log("DeeplinkClient:: Sending message \(message)")
             sendMessage(message)
         }
@@ -98,7 +100,7 @@ public class DeeplinkClient: CommClient {
             pubkey: nil,
             channelId: channelId,
             request: request
-        ))
+        ), options: [:])
     }
     
     public func track(event: Event) {
@@ -148,7 +150,7 @@ extension DeeplinkClient {
         }
     }
     
-    public func sendMessage(_ message: String, encrypt: Bool) {
+    public func sendMessage(_ message: String, encrypt: Bool, options: [String: String]) {
         let base64Encoded = message.base64Encode() ?? ""
         
         let deeplink: Deeplink = .mmsdk(
@@ -156,7 +158,7 @@ extension DeeplinkClient {
             pubkey: nil,
             channelId: channelId
         )
-        sendMessage(deeplink)
+        sendMessage(deeplink, options: options)
     }
     
     public func handleMessage(_ message: String) {

--- a/Sources/metamask-ios-sdk/Classes/CommunicationLayer/SocketCommLayer/SocketClient.swift
+++ b/Sources/metamask-ios-sdk/Classes/CommunicationLayer/SocketCommLayer/SocketClient.swift
@@ -367,7 +367,7 @@ extension SocketClient {
         }
     }
 
-    public func sendMessage<T: CodableData>(_ message: T, encrypt: Bool) {
+    public func sendMessage<T: CodableData>(_ message: T, encrypt: Bool, options: [String: String] = [:]) {
         if encrypt && !keyExchange.keysExchanged {
             addRequest { [weak self] in
                 guard let self = self else { return }

--- a/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
+++ b/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
@@ -409,7 +409,7 @@ public class Ethereum {
                         
                         let requestJson = json(from: requestDict) ?? ""
                         
-                        commClient.sendMessage(requestJson, encrypt: true)
+                        commClient.sendMessage(requestJson, encrypt: true, options: [:])
                     } catch {
                         Logging.error("Ethereum:: error: \(error.localizedDescription)")
                     }
@@ -438,7 +438,7 @@ public class Ethereum {
                         
                         let requestJson = json(from: requestDict) ?? ""
                         
-                        commClient.sendMessage(requestJson, encrypt: true)
+                        commClient.sendMessage(requestJson, encrypt: true, options: ["account": account, "chainId": chainId])
                     } catch {
                         Logging.error("Ethereum:: error: \(error.localizedDescription)")
                         return
@@ -449,7 +449,7 @@ public class Ethereum {
                             return
                         }
                                     
-                    commClient.sendMessage(requestJson, encrypt: true)
+                    commClient.sendMessage(requestJson, encrypt: true, options: ["account": account, "chainId": chainId])
                 }
             }
         }

--- a/metamask-ios-sdk.podspec
+++ b/metamask-ios-sdk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'metamask-ios-sdk'
-  s.version          = '0.6.4'
+  s.version          = '0.6.5'
   s.summary          = 'Enable users to easily connect with their MetaMask Mobile wallet.'
   s.swift_version    = '5.5'
 


### PR DESCRIPTION
This PR adds an account and chainId context to the deeplink communication so that the wallet can ascertain if the dapp is using the same account and chainId to cater for scenarios where the wallet's chain id and/or chainId may have changed unbeknownst to the dapp.