### PR TITLE
feat: always send dappId in every request

### DIFF
--- a/Sources/metamask-ios-sdk/Classes/CommunicationLayer/DeeplinkCommLayer/DeeplinkClient.swift
+++ b/Sources/metamask-ios-sdk/Classes/CommunicationLayer/DeeplinkCommLayer/DeeplinkClient.swift
@@ -108,7 +108,7 @@ public class DeeplinkClient: CommClient {
             "commLayer": "socket",
             "sdkVersion": SDKInfo.version,
             "url": appMetadata?.url ?? "",
-            "dappId": SDKInfo.bundleIdentifier ?? "",
+            "dappId": SDKInfo.bundleIdentifier ?? "N/A",
             "title": appMetadata?.name ?? "",
             "platform": SDKInfo.platform
         ]

--- a/Sources/metamask-ios-sdk/Classes/CommunicationLayer/DeeplinkCommLayer/DeeplinkClient.swift
+++ b/Sources/metamask-ios-sdk/Classes/CommunicationLayer/DeeplinkCommLayer/DeeplinkClient.swift
@@ -103,27 +103,15 @@ public class DeeplinkClient: CommClient {
     }
 
     public func track(event: Event) {
-        let id = channelId
-        var parameters: [String: Any] = ["id": id]
-
-        switch event {
-        case .connected,
-                .disconnected,
-                .reconnectionRequest,
-                .connectionAuthorised,
-                .connectionRejected,
-                .sdkRpcRequestDone:
-            break
-        case .connectionRequest, .sdkRpcRequest:
-            let additionalParams: [String: Any] = [
-                "commLayer": "deeplinking",
-                "sdkVersion": SDKInfo.version,
-                "url": appMetadata?.url ?? "",
-                "title": appMetadata?.name ?? "",
-                "platform": SDKInfo.platform
-            ]
-            parameters.merge(additionalParams) { current, _ in current }
-        }
+        let parameters: [String: Any] = [
+            "id": channelId,
+            "commLayer": "socket",
+            "sdkVersion": SDKInfo.version,
+            "url": appMetadata?.url ?? "",
+            "dappId": SDKInfo.bundleIdentifier ?? "",
+            "title": appMetadata?.name ?? "",
+            "platform": SDKInfo.platform
+        ]
 
         trackEvent?(event, parameters)
     }

--- a/Sources/metamask-ios-sdk/Classes/CommunicationLayer/SocketCommLayer/SocketClient.swift
+++ b/Sources/metamask-ios-sdk/Classes/CommunicationLayer/SocketCommLayer/SocketClient.swift
@@ -445,7 +445,7 @@ extension SocketClient {
             "commLayer": "socket",
             "sdkVersion": SDKInfo.version,
             "url": appMetadata?.url ?? "",
-            "dappId": SDKInfo.bundleIdentifier ?? "",
+            "dappId": SDKInfo.bundleIdentifier ?? "N/A",
             "title": appMetadata?.name ?? "",
             "platform": SDKInfo.platform
         ]

--- a/Sources/metamask-ios-sdk/Classes/CommunicationLayer/SocketCommLayer/SocketClient.swift
+++ b/Sources/metamask-ios-sdk/Classes/CommunicationLayer/SocketCommLayer/SocketClient.swift
@@ -440,22 +440,15 @@ extension SocketClient {
 
 extension SocketClient {
     public func track(event: Event) {
-        let id = channelId
-        var parameters: [String: Any] = ["id": id]
-
-        switch event {
-        case .connectionRequest, .sdkRpcRequest:
-            let additionalParams: [String: Any] = [
-                "commLayer": "socket",
-                "sdkVersion": SDKInfo.version,
-                "url": appMetadata?.url ?? "",
-                "title": appMetadata?.name ?? "",
-                "platform": SDKInfo.platform
-            ]
-            parameters.merge(additionalParams) { current, _ in current }
-        default:
-            break
-        }
+        let parameters: [String: Any] = [
+            "id": channelId,
+            "commLayer": "socket",
+            "sdkVersion": SDKInfo.version,
+            "url": appMetadata?.url ?? "",
+            "dappId": SDKInfo.bundleIdentifier ?? "",
+            "title": appMetadata?.name ?? "",
+            "platform": SDKInfo.platform
+        ]
 
         trackEvent?(event, parameters)
     }


### PR DESCRIPTION
This PR adds `dappId` to every request. It wasn't added to any request other than originator info which led to an empty `dappId` in events.