### PR TITLE
feat: session persistence v2 support

### DIFF
--- a/Example/Tests/DeeplinkClientTests.swift
+++ b/Example/Tests/DeeplinkClientTests.swift
@@ -22,7 +22,7 @@ class DeeplinkClientTests: XCTestCase {
         mockDeeplinkManager = MockDeeplinkManager()
 
         secureStore = Keychain(service: "com.example.deeplinkTestKeychain")
-        mockKeyExchange = MockKeyExchange()
+        mockKeyExchange = MockKeyExchange(storage: secureStore)
         mockURLOpener = MockURLOpener()
         mockSessionManager = MockSessionManager(store: secureStore, sessionDuration: 3600)
         deeplinkClient = DeeplinkClient(

--- a/Example/metamask-ios-sdk/ConnectView.swift
+++ b/Example/metamask-ios-sdk/ConnectView.swift
@@ -18,15 +18,13 @@ struct ConnectView: View {
     @State var selectedTransport: Transport = .deeplinking(dappScheme: DAPP_SCHEME)
     @State private var dappScheme: String = DAPP_SCHEME
 
-    private static let appMetadata = AppMetadata(
-        name: "Dub Dapp",
-        url: "https://dubdapp.com",
-        iconUrl: "https://cdn.sstatic.net/Sites/stackoverflow/Img/apple-touch-icon.png"
-    )
-
     // We recommend adding support for Infura API for read-only RPCs (direct calls) via SDKOptions
     @ObservedObject var metaMaskSDK = MetaMaskSDK.shared(
-                    appMetadata,
+        AppMetadata(
+            name: "Dub Dapp",
+            url: "https://dubdapp.com",
+            iconUrl: "https://cdn.sstatic.net/Sites/stackoverflow/Img/apple-touch-icon.png"
+        ),
                     transport: .deeplinking(dappScheme: DAPP_SCHEME),
                     sdkOptions: nil // SDKOptions(infuraAPIKey: "####")
                 )

--- a/Sources/metamask-ios-sdk/Classes/CommunicationLayer/SocketCommLayer/ClientEvent.swift
+++ b/Sources/metamask-ios-sdk/Classes/CommunicationLayer/SocketCommLayer/ClientEvent.swift
@@ -20,6 +20,10 @@ public struct ClientEvent {
     public static var joinChannel: String {
         "join_channel"
     }
+    
+    public static var channelPersistence: String {
+        "channel_persistence"
+    }
 
     public static func clientsConnected(on channel: String) -> String {
         "clients_connected".appending("-").appending(channel)
@@ -31,5 +35,9 @@ public struct ClientEvent {
 
     public static func message(on channelId: String) -> String {
         "message".appending("-").appending(channelId)
+    }
+    
+    public static func config(on channelId: String) -> String {
+        "config".appending("-").appending(channelId)
     }
 }

--- a/Sources/metamask-ios-sdk/Classes/CommunicationLayer/SocketCommLayer/ClientEvent.swift
+++ b/Sources/metamask-ios-sdk/Classes/CommunicationLayer/SocketCommLayer/ClientEvent.swift
@@ -20,10 +20,6 @@ public struct ClientEvent {
     public static var joinChannel: String {
         "join_channel"
     }
-    
-    public static var channelPersistence: String {
-        "channel_persistence"
-    }
 
     public static func clientsConnected(on channel: String) -> String {
         "clients_connected".appending("-").appending(channel)

--- a/Sources/metamask-ios-sdk/Classes/CommunicationLayer/SocketCommLayer/SocketChannel.swift
+++ b/Sources/metamask-ios-sdk/Classes/CommunicationLayer/SocketCommLayer/SocketChannel.swift
@@ -46,7 +46,7 @@ public class SocketChannel {
         socketManager = SocketManager(
             socketURL: url,
             config: [
-                .log(false),
+                .log(true),
                 .forceWebsockets(true),
                 options
             ]

--- a/Sources/metamask-ios-sdk/Classes/CommunicationLayer/SocketCommLayer/SocketChannel.swift
+++ b/Sources/metamask-ios-sdk/Classes/CommunicationLayer/SocketCommLayer/SocketChannel.swift
@@ -46,7 +46,7 @@ public class SocketChannel {
         socketManager = SocketManager(
             socketURL: url,
             config: [
-                .log(true),
+                .log(false),
                 .forceWebsockets(true),
                 options
             ]

--- a/Sources/metamask-ios-sdk/Classes/CommunicationLayer/SocketCommLayer/SocketClient.swift
+++ b/Sources/metamask-ios-sdk/Classes/CommunicationLayer/SocketCommLayer/SocketClient.swift
@@ -315,7 +315,6 @@ extension SocketClient {
             let message = try SocketMessage<String>.message(from: msg)
             try handleEncryptedMessage(message)
             if let ackId = message.ackId {
-                Logging.log("Sending ackId \(ackId) for message id \(message.id)")
                 channel.emit("ack", [
                     "ackId": ackId,
                     "channelId": channelId,

--- a/Sources/metamask-ios-sdk/Classes/Crypto/KeyExchange.swift
+++ b/Sources/metamask-ios-sdk/Classes/Crypto/KeyExchange.swift
@@ -33,14 +33,43 @@ public enum KeyExchangeError: Error {
 public struct KeyExchangeMessage: CodableData, Mappable {
     public let type: KeyExchangeType
     public let pubkey: String?
+    public var v: Int?
+    public var clientType: String? = "dapp"
 
-    public init(type: KeyExchangeType, pubkey: String?) {
+    public init(type: KeyExchangeType, pubkey: String?, v: Int? = 2, clientType: String? = "dapp") {
         self.type = type
         self.pubkey = pubkey
+        self.clientType = clientType
+        self.v = v
     }
 
+    // Custom initializer for decoding
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        type = try container.decode(KeyExchangeType.self, forKey: .type)
+        pubkey = try container.decodeIfPresent(String.self, forKey: .pubkey)
+        v = try container.decodeIfPresent(Int.self, forKey: .v) ?? 2
+        clientType = try container.decodeIfPresent(String.self, forKey: .clientType) ?? "dapp"
+    }
+
+    // Custom method for encoding
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(type, forKey: .type)
+        try container.encode(pubkey, forKey: .pubkey)
+        try container.encode(v, forKey: .v)
+        try container.encode(clientType, forKey: .clientType)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case pubkey
+        case v
+        case clientType
+    }
+    
     public func socketRepresentation() -> NetworkData {
-        ["type": type.rawValue, "pubkey": pubkey]
+        ["type": type.rawValue, "pubkey": pubkey, "v": v, "clientType": clientType]
     }
 }
 
@@ -52,16 +81,36 @@ public struct KeyExchangeMessage: CodableData, Mappable {
 
 public class KeyExchange {
     private var privateKey: String
-
     public var pubkey: String
     public private(set) var theirPublicKey: String?
 
+    private let storage: SecureStore
     private let encyption: Crypto.Type
     var keysExchanged: Bool = false
+    var isKeysExchangedViaV2Protocol: Bool = false
+    private let privateKeyStorageKey = "MM_SDK_PRIV_KEY"
+    private let theirPubliKeyStorageKey = "MM_SDK_THEIR_PUB_KEY"
 
-    public init(encryption: Crypto.Type = Ecies.self) {
-        encyption = encryption
-        privateKey = encyption.generatePrivateKey()
+    public init(encryption: Crypto.Type = Ecies.self, storage: SecureStore) {
+        self.storage = storage
+        self.encyption = encryption
+
+        if let storedPrivateKey = storage.string(for: privateKeyStorageKey) {
+            Logging.log("KeyExchange:: using stored private key")
+            self.privateKey = storedPrivateKey
+            
+            if let theirPubKey = storage.string(for: theirPubliKeyStorageKey) {
+                self.theirPublicKey = theirPubKey
+                
+                // wallet already has keys
+                keysExchanged = true
+                isKeysExchangedViaV2Protocol = true
+            }
+        } else {
+            Logging.log("KeyExchange:: generating new private key")
+            privateKey = encyption.generatePrivateKey()
+        }
+        
         do {
             pubkey = try encyption.publicKey(from: privateKey)
         } catch {
@@ -72,7 +121,12 @@ public class KeyExchange {
     public func reset() {
         keysExchanged = false
         theirPublicKey = nil
+        privateKey = ""
+        
+        storage.deleteData(for: privateKeyStorageKey)
+        storage.deleteData(for: theirPubliKeyStorageKey)
         privateKey = encyption.generatePrivateKey()
+        
         do {
             pubkey = try encyption.publicKey(from: privateKey)
         } catch {
@@ -90,6 +144,12 @@ public class KeyExchange {
             !publicKey.isEmpty {
             setTheirPublicKey(publicKey)
             keysExchanged = true
+            
+            if message.v == 2 {
+                self.storage.save(string: privateKey, key: privateKeyStorageKey)
+                self.storage.save(string: publicKey, key: theirPubliKeyStorageKey)
+                isKeysExchangedViaV2Protocol = true
+            }
         }
 
         guard let nextStep = nextStep(message.type) else {
@@ -121,6 +181,7 @@ public class KeyExchange {
     public func setTheirPublicKey(_ publicKey: String?) {
         if let theirPubKey = publicKey {
             theirPublicKey = theirPubKey
+            storage.save(string: theirPubKey, key: theirPubliKeyStorageKey)
         }
     }
 

--- a/Sources/metamask-ios-sdk/Classes/Persistence/SecureStore.swift
+++ b/Sources/metamask-ios-sdk/Classes/Persistence/SecureStore.swift
@@ -11,6 +11,9 @@ public protocol SecureStore {
 
     @discardableResult
     func deleteData(for key: String) -> Bool
+    
+    @discardableResult
+    func deleteAll() -> Bool
 
     @discardableResult
     func save(string: String, key: String) -> Bool
@@ -38,6 +41,12 @@ public struct Keychain: SecureStore {
 
     public func deleteData(for key: String) -> Bool {
         let request = deletionRequestForKey(key)
+        let status: OSStatus = SecItemDelete(request)
+        return status == errSecSuccess
+    }
+    
+    public func deleteAll() -> Bool {
+        let request = deletionRequestForAll()
         let status: OSStatus = SecItemDelete(request)
         return status == errSecSuccess
     }
@@ -101,6 +110,13 @@ public struct Keychain: SecureStore {
     private func deletionRequestForKey(_ key: String) -> CFDictionary {
         [
             kSecAttrAccount: key,
+            kSecAttrService: service,
+            kSecClass: kSecClassGenericPassword
+        ] as CFDictionary
+    }
+
+    private func deletionRequestForAll() -> CFDictionary {
+        [
             kSecAttrService: service,
             kSecClass: kSecClassGenericPassword
         ] as CFDictionary

--- a/Sources/metamask-ios-sdk/Classes/Persistence/SessionManager.swift
+++ b/Sources/metamask-ios-sdk/Classes/Persistence/SessionManager.swift
@@ -51,6 +51,6 @@ public class SessionManager {
     }
 
     public func clear() {
-        store.deleteData(for: SESSION_KEY)
+        store.deleteAll()
     }
 }

--- a/Sources/metamask-ios-sdk/Classes/SDK/Dependencies.swift
+++ b/Sources/metamask-ios-sdk/Classes/SDK/Dependencies.swift
@@ -28,12 +28,15 @@ public final class Dependencies {
         }.updateTransportLayer(transport)
     }
 
-    public lazy var keyExchange: KeyExchange = KeyExchange()
+    public lazy var keyExchange: KeyExchange = KeyExchange(storage: store)
 
     public lazy var deeplinkManager: DeeplinkManager = DeeplinkManager()
 
     public lazy var socketClient: CommClient = SocketClient(
         session: sessionManager,
+        channel: SocketChannel(),
+        keyExchange: keyExchange,
+        urlOpener: DefaultURLOpener(),
         trackEvent: { event, parameters in
             self.trackEvent(event, parameters: parameters)
         }

--- a/Sources/metamask-ios-sdk/Classes/SDK/MetaMaskSDK.swift
+++ b/Sources/metamask-ios-sdk/Classes/SDK/MetaMaskSDK.swift
@@ -3,6 +3,7 @@
 //
 
 import SwiftUI
+import UIKit
 import Combine
 import Foundation
 
@@ -64,6 +65,13 @@ public class MetaMaskSDK: ObservableObject {
         self.ethereum.updateMetadata(appMetadata)
         self.tracker.enableDebug = enableDebug
         setupAppLifeCycleObservers()
+    }
+    
+    public var isMetaMaskInstalled: Bool {
+        guard let url = URL(string: "metamask://") else {
+            return false
+        }
+        return UIApplication.shared.canOpenURL(url)
     }
 
     public func handleUrl(_ url: URL) {


### PR DESCRIPTION
This PR adds support for session persistence v2 protocol, whereby the encryption keys for the client to decrypt data and the server public key to encrypt data are stored in the secure enclave (keychain) and reused for future interactions.

The attached video is a demo for this feature, demonstrating how the wallet is able to handle dapp requests even after it was killed without requiring a connection request.


https://github.com/MetaMask/metamask-ios-sdk/assets/17785504/b5cf22d8-2d25-46a7-9647-09a9aa36076f

