### PR TITLE
chore: log done request for all responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Alternatively, you can add the URL directly in your project's package file:
 dependencies: [
     .package(
         url: "https://github.com/MetaMask/metamask-ios-sdk",
-        from: "0.7.0"
+        from: "0.7.1"
     )
 ]
 ```

--- a/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
+++ b/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
@@ -673,6 +673,11 @@ public class Ethereum {
 
     func receiveResponse(_ data: [String: Any], id: String) {
         guard let request = submittedRequests[id] else { return }
+        
+        track?(.sdkRpcRequestDone, [
+            "from": "mobile",
+            "method": request.method
+        ])
 
         if let error = data["error"] as? [String: Any] {
             let requestError = RequestError(from: error)
@@ -700,11 +705,6 @@ public class Ethereum {
 
             return
         }
-
-        track?(.sdkRpcRequestDone, [
-            "from": "mobile",
-            "method": request.method
-        ])
 
         guard
             let method = EthereumMethod(rawValue: request.method),

--- a/metamask-ios-sdk.podspec
+++ b/metamask-ios-sdk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'metamask-ios-sdk'
-  s.version          = '0.7.0'
+  s.version          = '0.7.1'
   s.summary          = 'Enable users to easily connect with their MetaMask Mobile wallet.'
   s.swift_version    = '5.5'
 


### PR DESCRIPTION
This PR ensures that all request-response events are logged for SDK_RPC_REQUEST_DONE. Previously, only success responses were logged.