### PR TITLE
chore: fix batch signing where one of the results is nil

### DIFF
--- a/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
+++ b/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
@@ -605,7 +605,8 @@ public class Ethereum {
                                 continuation.resume(returning: .failure(error))
                             }
                         }, receiveValue: { result in
-                            continuation.resume(returning: .success(result as? [String] ?? []))
+                            let value: [String] = (result as? [String?])?.compactMap{$0} ?? []
+                            continuation.resume(returning: .success(value))
                         }).store(in: &cancellables)
                 }
             } catch {


### PR DESCRIPTION
This PR fixes the case where one of the results in a batch signing is `nil` e.g `wallet_switchEthereumChain` where by the results ends up not being handled correctly as it previously expected non-nil result items