### PR TITLE
feat: sticky session persistence via account and chainId caching

### DIFF
--- a/Example/Tests/EthereumConnectTests.swift
+++ b/Example/Tests/EthereumConnectTests.swift
@@ -13,9 +13,11 @@ class EthereumConnectTests: XCTestCase {
     var commClientFactory: CommClientFactory!
     var trackEventMock: ((Event, [String: Any]) -> Void)!
     var ethereum: Ethereum!
+    var store: SecureStore!
     
     override func setUp() {
         super.setUp()
+        store = Keychain(service: "com.example.ethconnect")
         mockCommClient = MockCommClient()
         commClientFactory = CommClientFactory()
         trackEventMock = { _, _ in }
@@ -23,6 +25,7 @@ class EthereumConnectTests: XCTestCase {
         SDKWrapper.shared.sdk = nil
         ethereum = Ethereum.shared(
             transport: .socket,
+            store: store,
             commClientFactory: commClientFactory,
             trackEvent: trackEventMock)
     }
@@ -30,6 +33,7 @@ class EthereumConnectTests: XCTestCase {
     override func tearDown() {
         mockCommClient = nil
         trackEventMock = nil
+        store.deleteAll()
         ethereum = nil
         commClientFactory = nil
         EthereumWrapper.shared.ethereum = nil
@@ -39,8 +43,8 @@ class EthereumConnectTests: XCTestCase {
 
     // Test the singleton instance creation
     func testSingletonInstance() {
-        let instance1 = Ethereum.shared(transport: .socket, commClientFactory: commClientFactory, trackEvent: trackEventMock)
-        let instance2 = Ethereum.shared(transport: .socket, commClientFactory: commClientFactory, trackEvent: trackEventMock)
+        let instance1 = Ethereum.shared(transport: .socket, store: store, commClientFactory: commClientFactory, trackEvent: trackEventMock)
+        let instance2 = Ethereum.shared(transport: .socket, store: store, commClientFactory: commClientFactory, trackEvent: trackEventMock)
         XCTAssert(instance1 === instance2)
     }
     

--- a/Example/Tests/EthereumConvenienceMethodsTests.swift
+++ b/Example/Tests/EthereumConvenienceMethodsTests.swift
@@ -15,6 +15,7 @@ class EthereumConvenienceMethodsTests: XCTestCase {
     var ethereum: Ethereum!
     var mockInfuraProvider: MockInfuraProvider!
     let infuraApiKey = "testApiKey"
+    var store: SecureStore!
     var trackedEvents: [(Event, [String: Any])] = []
     
     override func setUp() {
@@ -24,6 +25,7 @@ class EthereumConvenienceMethodsTests: XCTestCase {
             self?.trackedEvents.append((event, params))
         }
         
+        store = Keychain(service: "com.example.ethconvenience")
         mockNetwork = MockNetwork()
         mockInfuraProvider = MockInfuraProvider(infuraAPIKey: infuraApiKey, network: mockNetwork)
         mockEthereumDelegate = MockEthereumDelegate()
@@ -31,6 +33,7 @@ class EthereumConvenienceMethodsTests: XCTestCase {
         SDKWrapper.shared.sdk = nil
         ethereum = Ethereum.shared(
             transport: .socket,
+            store: store,
             commClientFactory: mockCommClientFactory,
             infuraProvider: mockInfuraProvider,
             trackEvent: trackEventMock)
@@ -41,6 +44,7 @@ class EthereumConvenienceMethodsTests: XCTestCase {
         trackEventMock = nil
         ethereum = nil
         mockNetwork = nil
+        store.deleteAll()
         mockEthereumDelegate = nil
         mockInfuraProvider = nil
         mockCommClientFactory = nil

--- a/Example/Tests/SessionManagerTests.swift
+++ b/Example/Tests/SessionManagerTests.swift
@@ -19,6 +19,7 @@ class SessionManagerTests: XCTestCase {
 
     override func tearDown() {
         super.tearDown()
+        keychain.deleteAll()
         sessionManager.clear()
     }
 

--- a/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
+++ b/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
@@ -32,39 +32,49 @@ public class Ethereum {
     /// The active/selected MetaMask account address
     var account: String = ""
 
+    let store: SecureStore
     var commClient: CommClient
     public var transport: Transport
     var commClientFactory: CommClientFactory
     
     var track: ((Event, [String: Any]) -> Void)?
+    private let ACCOUNT_KEY = "ACCOUNT_KEY"
+    private let CHAINID_KEY = "CHAIN_ID_KEY"
     
 
     private init(transport: Transport,
+                 store: SecureStore,
                  commClientFactory: CommClientFactory,
                  infuraProvider: InfuraProvider? = nil,
                  track: @escaping ((Event, [String: Any]) -> Void)) {
         self.track = track
+        self.store = store
         self.transport = transport
+        
         switch transport {
         case .socket:
             self.commClient = commClientFactory.socketClient()
         case .deeplinking(let dappScheme):
             self.commClient = commClientFactory.deeplinkClient(dappScheme: dappScheme)
         }
+        
         self.commClientFactory = commClientFactory
         self.infuraProvider = infuraProvider
         self.commClient.trackEvent = trackEvent
         self.commClient.handleResponse = handleMessage
         self.commClient.onClientsTerminated = terminateConnection
+        fetchCachedSession()
     }
 
     public static func shared(transport: Transport,
+                              store: SecureStore,
                               commClientFactory: CommClientFactory,
                               infuraProvider: InfuraProvider? = nil,
                               trackEvent: @escaping ((Event, [String: Any]) -> Void)) -> Ethereum {
         guard let ethereum = EthereumWrapper.shared.ethereum else {
             let ethereum = Ethereum(
                 transport: transport,
+                store: store,
                 commClientFactory: commClientFactory,
                 infuraProvider: infuraProvider,
                 track: trackEvent)
@@ -73,16 +83,29 @@ public class Ethereum {
         }
         return ethereum
     }
+    
+    private func fetchCachedSession() {
+        guard case .deeplinking = transport else { return }
+        
+        if let account = store.string(for: ACCOUNT_KEY) {
+            self.account = account
+        }
+        if let chainId = store.string(for: CHAINID_KEY) {
+            self.chainId = chainId
+        }
+    }
 
     @discardableResult
     func updateTransportLayer(_ transport: Transport) -> Ethereum {
-        disconnect()
+        
         self.transport = transport
 
         switch transport {
         case .deeplinking(let dappScheme):
             commClient = commClientFactory.deeplinkClient(dappScheme: dappScheme)
+            fetchCachedSession()
         case .socket:
+            clearSession()
             commClient = commClientFactory.socketClient()
             commClient.onClientsTerminated = terminateConnection
         }
@@ -119,22 +142,59 @@ public class Ethereum {
 
         return publisher
     }
+    
+    func performAsyncOperation<T>(_ publisher: EthereumPublisher?, defaultValue: T) async -> Result<T, RequestError> {
+        guard let publisher = publisher else {
+            return .failure(.genericError)
+        }
 
-    @discardableResult
-    func connect() async -> Result<String, RequestError> {
         return await withCheckedContinuation { continuation in
-            connect()?
+            publisher
+                .tryMap { output in
+                    // remove nil and NSNUll values in result
+                    if  let resultArray = output as? [Any?] {
+                        let resultItems = resultArray
+                            .filter({ !($0 is NSNull) })
+                            .compactMap({ $0 })
+                        guard let result = resultItems as? T else {
+                            return defaultValue
+                        }
+                        return result
+                    }
+                    guard let result = output as? T else {
+                        return defaultValue
+                    }
+                    return result
+                }
+                .mapError { error in
+                    error as? RequestError ?? RequestError.responseError
+                }
                 .sink(receiveCompletion: { completion in
                     switch completion {
                     case .finished:
-                        continuation.resume(returning: .success(""))
+                        break
                     case .failure(let error):
                         continuation.resume(returning: .failure(error))
                     }
                 }, receiveValue: { result in
-                    continuation.resume(returning: .success("\(result)"))
+                    continuation.resume(returning: .success(result))
                 }).store(in: &cancellables)
         }
+    }
+    
+    func request(_ req: any RPCRequest) async -> Result<String, RequestError> {
+        let publisher = performRequest(req)
+        return await performAsyncOperation(publisher, defaultValue: String()) as Result<String, RequestError>
+    }
+    
+    func request(_ req: any RPCRequest) async -> Result<[String], RequestError> {
+        let publisher = performRequest(req)
+        return await performAsyncOperation(publisher, defaultValue: [String]()) as Result<[String], RequestError>
+    }
+    
+    @discardableResult
+    func connect() async -> Result<String, RequestError> {
+        await performAsyncOperation(connect(), defaultValue: String()) as Result<String, RequestError>
     }
 
     func connectAndSign(message: String) -> EthereumPublisher? {
@@ -146,7 +206,7 @@ public class Ethereum {
 
         if commClient is SocketClient {
             commClient.connect(with: nil)
-            return request(connectSignRequest)
+            return performRequest(connectSignRequest)
         }
 
         let submittedRequest = SubmittedRequest(method: connectSignRequest.method)
@@ -161,19 +221,7 @@ public class Ethereum {
     }
 
     func connectAndSign(message: String) async -> Result<String, RequestError> {
-        return await withCheckedContinuation { continuation in
-            connectAndSign(message: message)?
-                .sink(receiveCompletion: { completion in
-                    switch completion {
-                    case .finished:
-                        continuation.resume(returning: .success(""))
-                    case .failure(let error):
-                        continuation.resume(returning: .failure(error))
-                    }
-                }, receiveValue: { result in
-                    continuation.resume(returning: .success("\(result)"))
-                }).store(in: &cancellables)
-        }
+        await performAsyncOperation(connectAndSign(message: message), defaultValue: String()) as Result<String, RequestError>
     }
 
     func connectWith<T: CodableData>(_ req: EthereumRequest<T>) -> EthereumPublisher? {
@@ -203,9 +251,9 @@ public class Ethereum {
                     method: connectWithRequest.method,
                     params: connectWithParams
                 )
-                return request(connectRequest)
+                return performRequest(connectRequest)
             } else {
-                return request(connectWithRequest)
+                return performRequest(connectWithRequest)
             }
         case .deeplinking:
             let submittedRequest = SubmittedRequest(method: connectWithRequest.method)
@@ -247,21 +295,9 @@ public class Ethereum {
             return publisher
         }
     }
-
+    
     func connectWith<T: CodableData>(_ req: EthereumRequest<T>) async -> Result<String, RequestError> {
-        return await withCheckedContinuation { continuation in
-            connectWith(req)?
-                .sink(receiveCompletion: { completion in
-                    switch completion {
-                    case .finished:
-                        continuation.resume(returning: .success(""))
-                    case .failure(let error):
-                        continuation.resume(returning: .failure(error))
-                    }
-                }, receiveValue: { result in
-                    continuation.resume(returning: .success("\(result)"))
-                }).store(in: &cancellables)
-        }
+        return await performAsyncOperation(connectWith(req), defaultValue: String()) as Result<String, RequestError>
     }
 
     // MARK: Convenience Methods
@@ -365,15 +401,15 @@ public class Ethereum {
 
     /// Disconnect dapp
     func disconnect() {
-        updateChainId("")
-        updateAccount("")
         connected = false
         commClient.disconnect()
     }
 
     func clearSession() {
-        updateAccount("")
         updateChainId("")
+        updateAccount("")
+        store.deleteData(for: ACCOUNT_KEY)
+        store.deleteData(for: CHAINID_KEY)
         connected = false
         commClient.clearSession()
     }
@@ -388,7 +424,7 @@ public class Ethereum {
             submittedRequests[key]?.error(error)
         }
         submittedRequests.removeAll()
-        disconnect()
+        clearSession()
     }
 
     // MARK: Request Sending
@@ -496,10 +532,10 @@ public class Ethereum {
     /// Performs and Ethereum remote procedural call (RPC)
     /// - Parameter request: The RPC request. It's `parameters` need to conform to `CodableData`
     /// - Returns: A Combine publisher that will emit a result or error once a response is received
-    func request(_ request: any RPCRequest) -> EthereumPublisher? {
+    func performRequest(_ request: any RPCRequest) -> EthereumPublisher? {
         let isConnectMethod = EthereumMethod.isConnectMethod(request.methodType)
         
-        if !connected && !isConnectMethod {
+        if !connected && !isConnectMethod && account.isEmpty {
             if request.methodType == .ethRequestAccounts {
                 commClient.connect(with: nil)
                 connected = true
@@ -512,7 +548,8 @@ public class Ethereum {
             submittedRequests[id] = submittedRequest
             let publisher = submittedRequests[id]?.publisher
 
-            if connected {
+            if connected || !account.isEmpty {
+                connected = true
                 sendRequest(request)
             } else {
                 commClient.connect(with: nil)
@@ -522,38 +559,6 @@ public class Ethereum {
                 }
             }
             return publisher
-        }
-    }
-
-    func request(_ req: any RPCRequest) async -> Result<String, RequestError> {
-        return await withCheckedContinuation { continuation in
-            request(req)?
-                .sink(receiveCompletion: { completion in
-                    switch completion {
-                    case .finished:
-                        continuation.resume(returning: .success(""))
-                    case .failure(let error):
-                        continuation.resume(returning: .failure(error))
-                    }
-                }, receiveValue: { result in
-                    continuation.resume(returning: .success(result as? String ?? ""))
-                }).store(in: &cancellables)
-        }
-    }
-
-    func request(_ req: any RPCRequest) async -> Result<[String], RequestError> {
-        return await withCheckedContinuation { continuation in
-            request(req)?
-                .sink(receiveCompletion: { completion in
-                    switch completion {
-                    case .finished:
-                        continuation.resume(returning: .success([]))
-                    case .failure(let error):
-                        continuation.resume(returning: .failure(error))
-                    }
-                }, receiveValue: { result in
-                    continuation.resume(returning: .success(result as? [String] ?? []))
-                }).store(in: &cancellables)
         }
     }
     
@@ -595,20 +600,7 @@ public class Ethereum {
                     method: EthereumMethod.metamaskBatch.rawValue,
                     params: jsonData)
 
-                return await withCheckedContinuation { continuation in
-                    request(batchReq)?
-                        .sink(receiveCompletion: { completion in
-                            switch completion {
-                            case .finished:
-                                continuation.resume(returning: .success([]))
-                            case .failure(let error):
-                                continuation.resume(returning: .failure(error))
-                            }
-                        }, receiveValue: { result in
-                            let value: [String] = (result as? [String?])?.compactMap{$0} ?? []
-                            continuation.resume(returning: .success(value))
-                        }).store(in: &cancellables)
-                }
+                return await performAsyncOperation(performRequest(batchReq), defaultValue: [String]()) as Result<[String], RequestError>
             } catch {
                 Logging.error("Ethereum:: error: \(error.localizedDescription)")
                 return .failure(RequestError(from: ["message": error.localizedDescription]))
@@ -618,19 +610,7 @@ public class Ethereum {
                 method: EthereumMethod.metamaskBatch.rawValue,
                 params: requests)
 
-            return await withCheckedContinuation { continuation in
-                request(batchRequest)?
-                    .sink(receiveCompletion: { completion in
-                        switch completion {
-                        case .finished:
-                            continuation.resume(returning: .success([]))
-                        case .failure(let error):
-                            continuation.resume(returning: .failure(error))
-                        }
-                    }, receiveValue: { result in
-                        continuation.resume(returning: .success(result as? [String] ?? []))
-                    }).store(in: &cancellables)
-            }
+            return await performAsyncOperation(performRequest(batchRequest), defaultValue: [String]()) as Result<[String], RequestError>
         }
     }
 
@@ -638,11 +618,17 @@ public class Ethereum {
     private func updateChainId(_ id: String) {
         chainId = id
         delegate?.chainIdChanged(id)
+        
+        guard !id.isEmpty else { return }
+        store.save(string: id, key: CHAINID_KEY)
     }
 
     private func updateAccount(_ account: String) {
         self.account = account
         delegate?.accountChanged(account)
+        
+        guard !account.isEmpty else { return }
+        store.save(string: account, key: ACCOUNT_KEY)
     }
 
     func sendResult(_ result: Any, id: String) {

--- a/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
+++ b/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
@@ -87,11 +87,13 @@ public class Ethereum {
     private func fetchCachedSession() {
         guard case .deeplinking = transport else { return }
         
-        if let account = store.string(for: ACCOUNT_KEY) {
+        if 
+            let account = store.string(for: ACCOUNT_KEY),
+            let chainId = store.string(for: CHAINID_KEY)
+        {
             self.account = account
-        }
-        if let chainId = store.string(for: CHAINID_KEY) {
             self.chainId = chainId
+            connected = true
         }
     }
 

--- a/Sources/metamask-ios-sdk/Classes/Ethereum/RequestError.swift
+++ b/Sources/metamask-ios-sdk/Classes/Ethereum/RequestError.swift
@@ -25,6 +25,13 @@ public struct RequestError: Codable, Error {
     public var localizedDescription: String {
         message
     }
+    
+    public static var genericError: RequestError {
+        RequestError(from: [
+            "code": -100,
+            "message": "Something went wrong"
+        ])
+    }
 
     public static var connectError: RequestError {
         RequestError(from: [
@@ -35,22 +42,29 @@ public struct RequestError: Codable, Error {
 
     public static var invalidUrlError: RequestError {
         RequestError(from: [
-            "code": -101,
+            "code": -102,
             "message": "Please use a valid url in AppMetaData"
         ])
     }
 
     public static var invalidTitleError: RequestError {
         RequestError(from: [
-            "code": -101,
+            "code": -103,
             "message": "Please use a valid name in AppMetaData"
         ])
     }
 
     public static var invalidBatchRequestError: RequestError {
         RequestError(from: [
-            "code": -101,
+            "code": -104,
             "message": "Something went wrong, check that your requests are valid"
+        ])
+    }
+    
+    public static var responseError: RequestError {
+        RequestError(from: [
+            "code": -105,
+            "message": "Unexpected response"
         ])
     }
 

--- a/Sources/metamask-ios-sdk/Classes/Models/AddChainParameters.swift
+++ b/Sources/metamask-ios-sdk/Classes/Models/AddChainParameters.swift
@@ -12,6 +12,15 @@ public struct AddChainParameters: CodableData {
     public let iconUrls: [String]?
     public let blockExplorerUrls: [String]?
     public let nativeCurrency: NativeCurrency
+    
+    public init(chainId: String, chainName: String, rpcUrls: [String], iconUrls: [String]?, blockExplorerUrls: [String]?, nativeCurrency: NativeCurrency) {
+        self.chainId = chainId
+        self.chainName = chainName
+        self.rpcUrls = rpcUrls
+        self.iconUrls = iconUrls
+        self.blockExplorerUrls = blockExplorerUrls
+        self.nativeCurrency = nativeCurrency
+    }
 
     public func socketRepresentation() -> NetworkData {
         [

--- a/Sources/metamask-ios-sdk/Classes/SDK/Dependencies.swift
+++ b/Sources/metamask-ios-sdk/Classes/SDK/Dependencies.swift
@@ -16,7 +16,10 @@ public final class Dependencies {
     public lazy var commClientFactory: CommClientFactory = CommClientFactory()
 
     public func ethereum(transport: Transport) -> Ethereum {
-        Ethereum.shared(transport: transport, commClientFactory: commClientFactory) { event, parameters in
+        Ethereum.shared(
+            transport: transport,
+            store: store,
+            commClientFactory: commClientFactory) { event, parameters in
             self.trackEvent(event, parameters: parameters)
         }.updateTransportLayer(transport)
     }

--- a/Sources/metamask-ios-sdk/Classes/SDK/MetaMaskSDK.swift
+++ b/Sources/metamask-ios-sdk/Classes/SDK/MetaMaskSDK.swift
@@ -64,6 +64,8 @@ public class MetaMaskSDK: ObservableObject {
         self.ethereum.sdkOptions = sdkOptions
         self.ethereum.updateMetadata(appMetadata)
         self.tracker.enableDebug = enableDebug
+        self.account = ethereum.account
+        self.chainId = ethereum.chainId
         setupAppLifeCycleObservers()
     }
     


### PR DESCRIPTION
This PR 
• Persists a session beyond the killing of the dapp by caching the chainId and selected address. When dapp is launched, it fetches these in the keychain and enables requests to be made right away without need to reconnect. If or when the session has been cleared in the wallet, the wallet responds with an unauthorised error and the dapp purges the stored session, necessitating a reconnection.

• Minor refactor for sending request to avoid duplication of combine publish

This feature is only available on deeplink communication layer

Fixes https://github.com/orgs/MetaMask/projects/97/views/1?pane=issue&itemId=70875732


https://github.com/user-attachments/assets/d28858d1-0320-434c-bbae-bd950817b9f0

