### PR TITLE
chore: sync dapp state after async fetching cached state

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Alternatively, you can add the URL directly in your project's package file:
 dependencies: [
     .package(
         url: "https://github.com/MetaMask/metamask-ios-sdk",
-        from: "0.8.0"
+        from: "0.8.1"
     )
 ]
 ```

--- a/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
+++ b/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
@@ -93,6 +93,8 @@ public class Ethereum {
             self.account = account
             self.chainId = chainId
             connected = true
+            delegate?.accountChanged(account)
+            delegate?.chainIdChanged(chainId)
         }
     }
 

--- a/metamask-ios-sdk.podspec
+++ b/metamask-ios-sdk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'metamask-ios-sdk'
-  s.version          = '0.8.0'
+  s.version          = '0.8.1'
   s.summary          = 'Enable users to easily connect with their MetaMask Mobile wallet.'
   s.swift_version    = '5.5'
 


### PR DESCRIPTION
This PR ensures that the dapp updates the consumer of the sdk after it has fetched a cached session on startup