### PR TITLE
chore: import foundation when using uuid

### DIFF
--- a/Sources/metamask-ios-sdk/Classes/CommunicationLayer/SocketCommLayer/SocketClientProtocol.swift
+++ b/Sources/metamask-ios-sdk/Classes/CommunicationLayer/SocketCommLayer/SocketClientProtocol.swift
@@ -2,6 +2,7 @@
 //  SocketProtocol.swift
 //
 
+import Foundation
 import SocketIO
 
 protocol SocketProtocol {

--- a/metamask-ios-sdk.podspec
+++ b/metamask-ios-sdk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'metamask-ios-sdk'
-  s.version          = '0.8.1'
+  s.version          = '0.8.2'
   s.summary          = 'Enable users to easily connect with their MetaMask Mobile wallet.'
   s.swift_version    = '5.5'
 


### PR DESCRIPTION
This PF fixes #177 caused by using a UUID without importing the Foundation framework. Our development Xcode version is 15.2 and the developer is using Xcode 15.4, meaning Xcode has since made it mandatory to import Foundation when using Foundation primitives.