### PR TITLE
chore: remove socket as the default transport layer

### DIFF
--- a/Sources/metamask-ios-sdk/Classes/CommunicationLayer/CommLayer.swift
+++ b/Sources/metamask-ios-sdk/Classes/CommunicationLayer/CommLayer.swift
@@ -5,8 +5,13 @@
 
 import Foundation
 
+/**
+ An enum representing the communication types supported for communication with MetaMask wallet
+ **/
 public enum Transport: CaseIterable, Identifiable, Hashable {
+    /// Uses socket.io as a transport mechanism
     case socket
+    /// Uses deeplinking as transport mechanism. Recommended. Requires setting URI scheme
     case deeplinking(dappScheme: String)
 
     public var id: String {

--- a/Sources/metamask-ios-sdk/Classes/SDK/MetaMaskSDK.swift
+++ b/Sources/metamask-ios-sdk/Classes/SDK/MetaMaskSDK.swift
@@ -81,7 +81,7 @@ public class MetaMaskSDK: ObservableObject {
     }
 
     public static func shared(_ appMetadata: AppMetadata,
-                              transport: Transport = .socket,
+                              transport: Transport,
                               enableDebug: Bool = true,
                               sdkOptions: SDKOptions?) -> MetaMaskSDK {
         guard let sdk = SDKWrapper.shared.sdk else {


### PR DESCRIPTION
This PR:
• Remove socket.io as the default communication layer to make developers aware of the better `.deeplinking` option
• Added documentation to explain what each transport layer option does

<img width="645" alt="Screenshot 2024-08-02 at 14 27 37" src="https://github.com/user-attachments/assets/2a2f4c79-931a-467a-834b-914c7728ef15">
