### PR TITLE
chore: send transaction updates

### DIFF
--- a/Example/Tests/EthereumConvenienceMethodsTests.swift
+++ b/Example/Tests/EthereumConvenienceMethodsTests.swift
@@ -176,7 +176,7 @@ class EthereumConvenienceMethodsTests: XCTestCase {
 
         let expectation = self.expectation(description: "Request should return transaction hash result")
         performSuccessfulTask({
-            await self.ethereum.sendTransaction(from: "0x1234", to: "0x5678", amount: "0x10")
+            await self.ethereum.sendTransaction(from: "0x1234", to: "0x5678", value: "0x10")
         }, expectedValue: transactionHash, expectation: expectation)
         sendResultAndAwait(transactionHash, method: .ethSendTransaction)
         await fulfillment(of: [expectation], timeout: 2.0)

--- a/Example/metamask-ios-sdk/TransactionView.swift
+++ b/Example/metamask-ios-sdk/TransactionView.swift
@@ -11,7 +11,7 @@ import metamask_ios_sdk
 struct TransactionView: View {
     @EnvironmentObject var metamaskSDK: MetaMaskSDK
 
-    @State private var amount = "0x000000000000000001"
+    @State private var value = "0x8ac7230489e80000"
     @State var result: String = ""
     @State private var errorMessage = ""
     @State private var showError = false
@@ -43,9 +43,9 @@ struct TransactionView: View {
             }
 
             Section {
-                Text("Amount")
+                Text("Value")
                     .modifier(TextCallout())
-                TextField("Amount", text: $amount)
+                TextField("Value", text: $amount)
                     .modifier(TextCaption())
                     .frame(minHeight: 32)
                     .modifier(TextCurvature())
@@ -108,7 +108,7 @@ struct TransactionView: View {
 
         let transactionResult = isConnectWith
         ? await metamaskSDK.connectWith(transactionRequest)
-        : await metamaskSDK.sendTransaction(from: metamaskSDK.account, to: to, amount: amount)
+        : await metamaskSDK.sendTransaction(from: metamaskSDK.account, to: to, value: value)
 
         showProgressView = false
 

--- a/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
+++ b/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
@@ -343,12 +343,12 @@ public class Ethereum {
         await ethereumRequest(method: .ethSignTypedDataV4, params: [address, typedData])
     }
 
-    func sendTransaction(from: String, to: String, amount: String) async -> Result<String, RequestError> {
+    func sendTransaction(from: String, to: String, value: String) async -> Result<String, RequestError> {
         await ethereumRequest(method: .ethSendTransaction, params: [
             [
                 "from": from,
                 "to": to,
-                "amount": amount
+                "value": value
             ]
         ])
     }

--- a/Sources/metamask-ios-sdk/Classes/SDK/MetaMaskSDK.swift
+++ b/Sources/metamask-ios-sdk/Classes/SDK/MetaMaskSDK.swift
@@ -170,8 +170,8 @@ public extension MetaMaskSDK {
         await ethereum.signTypedDataV4(typedData: typedData, address: address)
     }
 
-    func sendTransaction(from: String, to: String, amount: String) async -> Result<String, RequestError> {
-        await ethereum.sendTransaction(from: from, to: to, amount: amount)
+    func sendTransaction(from: String, to: String, value: String) async -> Result<String, RequestError> {
+        await ethereum.sendTransaction(from: from, to: to, value: value)
     }
 
     func sendRawTransaction(signedTransaction: String) async -> Result<String, RequestError> {

--- a/metamask-ios-sdk.podspec
+++ b/metamask-ios-sdk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'metamask-ios-sdk'
-  s.version          = '0.8.2'
+  s.version          = '0.8.3'
   s.summary          = 'Enable users to easily connect with their MetaMask Mobile wallet.'
   s.swift_version    = '5.5'
 


### PR DESCRIPTION
This PR fixes the `sendTransaction` convenience method. Previously it used amount instead of value for the value field which was incorrect.