### PR TITLE
chore: provide api version override in app metadata

### DIFF
--- a/Sources/metamask-ios-sdk/Classes/CommunicationLayer/CommClient.swift
+++ b/Sources/metamask-ios-sdk/Classes/CommunicationLayer/CommClient.swift
@@ -31,7 +31,7 @@ public extension CommClient {
             icon: appMetadata?.iconUrl ?? appMetadata?.base64Icon,
             dappId: SDKInfo.bundleIdentifier,
             platform: SDKInfo.platform,
-            apiVersion: SDKInfo.version
+            apiVersion: appMetadata?.apiVersion ?? SDKInfo.version
         )
 
         return RequestInfo(

--- a/Sources/metamask-ios-sdk/Classes/CommunicationLayer/CommClient.swift
+++ b/Sources/metamask-ios-sdk/Classes/CommunicationLayer/CommClient.swift
@@ -31,8 +31,7 @@ public extension CommClient {
             icon: appMetadata?.iconUrl ?? appMetadata?.base64Icon,
             dappId: SDKInfo.bundleIdentifier,
             platform: SDKInfo.platform,
-            apiVersion: appMetadata?.apiVersion ?? SDKInfo.version
-        )
+            apiVersion: appMetadata?.apiVersion ?? SDKInfo.version)
 
         return RequestInfo(
             type: "originator_info",

--- a/Sources/metamask-ios-sdk/Classes/Ethereum/AppMetadata.swift
+++ b/Sources/metamask-ios-sdk/Classes/Ethereum/AppMetadata.swift
@@ -9,16 +9,20 @@ public struct AppMetadata {
     public let url: String
     public let iconUrl: String?
     public let base64Icon: String?
+    public let apiVersion: String?
 
     var platform: String = "ios"
 
     public init(name: String,
                 url: String,
                 iconUrl: String? = nil,
-                base64Icon: String? = nil) {
+                base64Icon: String? = nil,
+                apiVersion: String? = nil
+    ) {
         self.name = name
         self.url = url
         self.iconUrl = iconUrl
+        self.apiVersion = apiVersion
         self.base64Icon = base64Icon
     }
 }


### PR DESCRIPTION
This PR fixes an issue on React Native SDK whereby the wrong api version is read from the app's plist's CFBundleShortVersionString.

Fixes [923](https://github.com/MetaMask/metamask-sdk/issues/923)