### PR TITLE
feature: add ability to specify read-only rpc map

### DIFF
--- a/Example/Tests/EthereumConnectTests.swift
+++ b/Example/Tests/EthereumConnectTests.swift
@@ -14,6 +14,8 @@ class EthereumConnectTests: XCTestCase {
     var trackEventMock: ((Event, [String: Any]) -> Void)!
     var ethereum: Ethereum!
     var store: SecureStore!
+    var mockNetwork: MockNetwork!
+    var mockReadOnlyRPCProvider: MockReadOnlyRPCProvider!
     
     override func setUp() {
         super.setUp()
@@ -23,10 +25,13 @@ class EthereumConnectTests: XCTestCase {
         trackEventMock = { _, _ in }
         EthereumWrapper.shared.ethereum = nil
         SDKWrapper.shared.sdk = nil
+        mockNetwork = MockNetwork()
+        mockReadOnlyRPCProvider = MockReadOnlyRPCProvider(infuraAPIKey: "12345", readonlyRPCMap: [:], network: mockNetwork)
         ethereum = Ethereum.shared(
             transport: .socket,
             store: store,
-            commClientFactory: commClientFactory,
+            commClientFactory: commClientFactory, 
+            readOnlyRPCProvider: mockReadOnlyRPCProvider,
             trackEvent: trackEventMock)
     }
 
@@ -43,8 +48,18 @@ class EthereumConnectTests: XCTestCase {
 
     // Test the singleton instance creation
     func testSingletonInstance() {
-        let instance1 = Ethereum.shared(transport: .socket, store: store, commClientFactory: commClientFactory, trackEvent: trackEventMock)
-        let instance2 = Ethereum.shared(transport: .socket, store: store, commClientFactory: commClientFactory, trackEvent: trackEventMock)
+        let instance1 = Ethereum.shared(
+            transport: .socket,
+            store: store,
+            commClientFactory: commClientFactory,
+            readOnlyRPCProvider: mockReadOnlyRPCProvider,
+            trackEvent: trackEventMock)
+        let instance2 = Ethereum.shared(
+            transport: .socket,
+            store: store,
+            commClientFactory: commClientFactory,
+            readOnlyRPCProvider: mockReadOnlyRPCProvider,
+            trackEvent: trackEventMock)
         XCTAssert(instance1 === instance2)
     }
     

--- a/Example/Tests/EthereumConvenienceMethodsTests.swift
+++ b/Example/Tests/EthereumConvenienceMethodsTests.swift
@@ -13,7 +13,7 @@ class EthereumConvenienceMethodsTests: XCTestCase {
     var mockEthereumDelegate: MockEthereumDelegate!
     var trackEventMock: ((Event, [String: Any]) -> Void)!
     var ethereum: Ethereum!
-    var mockInfuraProvider: MockInfuraProvider!
+    var mockReadOnlyRPCProvider: MockReadOnlyRPCProvider!
     let infuraApiKey = "testApiKey"
     var store: SecureStore!
     var trackedEvents: [(Event, [String: Any])] = []
@@ -27,7 +27,7 @@ class EthereumConvenienceMethodsTests: XCTestCase {
         
         store = Keychain(service: "com.example.ethconvenience")
         mockNetwork = MockNetwork()
-        mockInfuraProvider = MockInfuraProvider(infuraAPIKey: infuraApiKey, network: mockNetwork)
+        mockReadOnlyRPCProvider = MockReadOnlyRPCProvider(infuraAPIKey: infuraApiKey, network: mockNetwork)
         mockEthereumDelegate = MockEthereumDelegate()
         EthereumWrapper.shared.ethereum = nil
         SDKWrapper.shared.sdk = nil
@@ -35,7 +35,7 @@ class EthereumConvenienceMethodsTests: XCTestCase {
             transport: .socket,
             store: store,
             commClientFactory: mockCommClientFactory,
-            infuraProvider: mockInfuraProvider,
+            readOnlyRPCProvider: mockReadOnlyRPCProvider,
             trackEvent: trackEventMock)
         ethereum.delegate = mockEthereumDelegate
     }
@@ -46,7 +46,7 @@ class EthereumConvenienceMethodsTests: XCTestCase {
         mockNetwork = nil
         store.deleteAll()
         mockEthereumDelegate = nil
-        mockInfuraProvider = nil
+        mockReadOnlyRPCProvider = nil
         mockCommClientFactory = nil
         EthereumWrapper.shared.ethereum = nil
         SDKWrapper.shared.sdk = nil
@@ -55,7 +55,7 @@ class EthereumConvenienceMethodsTests: XCTestCase {
    
     func testGetChainId() async {
         ethereum.connected = true
-        ethereum.infuraProvider = nil
+        ethereum.readOnlyRPCProvider = nil
         let chainId = "0x1"
         
         let expectation = self.expectation(description: "Request should return chainId")
@@ -69,7 +69,7 @@ class EthereumConvenienceMethodsTests: XCTestCase {
 
     func testGetEthAccounts() async {
         ethereum.connected = true
-        ethereum.infuraProvider = nil
+        ethereum.readOnlyRPCProvider = nil
         let accounts = ["0x1234"]
          
          let expectation = self.expectation(description: "Request should return accounts")
@@ -83,7 +83,7 @@ class EthereumConvenienceMethodsTests: XCTestCase {
     
     func testGetEthGasPrice() async {
         ethereum.connected = true
-        ethereum.infuraProvider = nil
+        ethereum.readOnlyRPCProvider = nil
         let balance = "0x1000"
 
         let expectation = self.expectation(description: "Request should return gas price")
@@ -96,7 +96,7 @@ class EthereumConvenienceMethodsTests: XCTestCase {
     
     func testGetEthBalance() async {
         ethereum.connected = true
-        ethereum.infuraProvider = nil
+        ethereum.readOnlyRPCProvider = nil
         let balance = "0x1000"
 
         let expectation = self.expectation(description: "Request should return balance")
@@ -109,7 +109,7 @@ class EthereumConvenienceMethodsTests: XCTestCase {
     
     func testGetEthBlockNumber() async {
         ethereum.connected = true
-        ethereum.infuraProvider = nil
+        ethereum.readOnlyRPCProvider = nil
         let blockNumber = "0x10"
 
         let expectation = self.expectation(description: "Request should return block number")
@@ -122,7 +122,7 @@ class EthereumConvenienceMethodsTests: XCTestCase {
     
     func testGetEthEstimateGas() async {
         ethereum.connected = true
-        ethereum.infuraProvider = nil
+        ethereum.readOnlyRPCProvider = nil
         let gasEstimate = "0x5208"
 
         let expectation = self.expectation(description: "Request should return gas estimate")
@@ -135,7 +135,7 @@ class EthereumConvenienceMethodsTests: XCTestCase {
     
     func testGetWeb3ClientVersion() async {
         ethereum.connected = true
-        ethereum.infuraProvider = nil
+        ethereum.readOnlyRPCProvider = nil
         let web3Version = "Geth/v1.8.23-stable"
 
         let expectation = self.expectation(description: "Request should return web3 version")
@@ -184,7 +184,7 @@ class EthereumConvenienceMethodsTests: XCTestCase {
     
     func testSendRawTransaction() async {
         ethereum.connected = true
-        ethereum.infuraProvider = nil
+        ethereum.readOnlyRPCProvider = nil
         let transactionHash = "0x345678"
 
         let expectation = self.expectation(description: "Request should return transaction hash result")
@@ -197,7 +197,7 @@ class EthereumConvenienceMethodsTests: XCTestCase {
     
     func testGetBlockTransactionCountByNumber() async {
         ethereum.connected = true
-        ethereum.infuraProvider = nil
+        ethereum.readOnlyRPCProvider = nil
         let transactionCount = "0x20"
 
         let expectation = self.expectation(description: "Request should return transaction count")
@@ -210,7 +210,7 @@ class EthereumConvenienceMethodsTests: XCTestCase {
     
     func testGetBlockTransactionCountByHash() async {
         ethereum.connected = true
-        ethereum.infuraProvider = nil
+        ethereum.readOnlyRPCProvider = nil
         let transactionCount = "0x30"
 
         let expectation = self.expectation(description: "Request should return transaction count")
@@ -223,7 +223,7 @@ class EthereumConvenienceMethodsTests: XCTestCase {
     
     func testGetTransactionCount() async {
         ethereum.connected = true
-        ethereum.infuraProvider = nil
+        ethereum.readOnlyRPCProvider = nil
         let transactionCount = "0x40"
 
         let expectation = self.expectation(description: "Request should return transaction count")

--- a/Example/Tests/EthereumConvenienceMethodsTests.swift
+++ b/Example/Tests/EthereumConvenienceMethodsTests.swift
@@ -27,7 +27,10 @@ class EthereumConvenienceMethodsTests: XCTestCase {
         
         store = Keychain(service: "com.example.ethconvenience")
         mockNetwork = MockNetwork()
-        mockReadOnlyRPCProvider = MockReadOnlyRPCProvider(infuraAPIKey: infuraApiKey, network: mockNetwork)
+        mockReadOnlyRPCProvider = MockReadOnlyRPCProvider(
+            infuraAPIKey: infuraApiKey,
+            readonlyRPCMap: [:],
+            network: mockNetwork)
         mockEthereumDelegate = MockEthereumDelegate()
         EthereumWrapper.shared.ethereum = nil
         SDKWrapper.shared.sdk = nil
@@ -55,7 +58,6 @@ class EthereumConvenienceMethodsTests: XCTestCase {
    
     func testGetChainId() async {
         ethereum.connected = true
-        ethereum.readOnlyRPCProvider = nil
         let chainId = "0x1"
         
         let expectation = self.expectation(description: "Request should return chainId")
@@ -63,13 +65,13 @@ class EthereumConvenienceMethodsTests: XCTestCase {
             ethereum.getChainId,
             expectedValue: chainId,
             expectation: expectation)
+        mockReadOnlyRPCProvider.expectation = expectation
         sendResultAndAwait(chainId, method: .ethChainId)
         await fulfillment(of: [expectation], timeout: 2.0)
     }
 
     func testGetEthAccounts() async {
         ethereum.connected = true
-        ethereum.readOnlyRPCProvider = nil
         let accounts = ["0x1234"]
          
          let expectation = self.expectation(description: "Request should return accounts")
@@ -77,71 +79,72 @@ class EthereumConvenienceMethodsTests: XCTestCase {
             ethereum.getEthAccounts,
             expectedValue: accounts,
             expectation: expectation)
+        mockReadOnlyRPCProvider.expectation = expectation
         sendResultAndAwait(accounts, method: .ethAccounts)
         await fulfillment(of: [expectation], timeout: 2.0)
     }
     
     func testGetEthGasPrice() async {
         ethereum.connected = true
-        ethereum.readOnlyRPCProvider = nil
         let balance = "0x1000"
 
         let expectation = self.expectation(description: "Request should return gas price")
         performSuccessfulTask(ethereum.getEthGasPrice,
                               expectedValue: balance,
                               expectation: expectation)
+        mockReadOnlyRPCProvider.expectation = expectation
         sendResultAndAwait(balance, method: .ethGasPrice)
         await fulfillment(of: [expectation], timeout: 2.0)
     }
     
     func testGetEthBalance() async {
         ethereum.connected = true
-        ethereum.readOnlyRPCProvider = nil
         let balance = "0x1000"
 
         let expectation = self.expectation(description: "Request should return balance")
         performSuccessfulTask({
             await self.ethereum.getEthBalance(address: "0x1234", block: "latest")
         }, expectedValue: balance, expectation: expectation)
+        mockReadOnlyRPCProvider.expectation = expectation
         sendResultAndAwait(balance, method: .ethGetBalance)
         await fulfillment(of: [expectation], timeout: 2.0)
     }
     
     func testGetEthBlockNumber() async {
         ethereum.connected = true
-        ethereum.readOnlyRPCProvider = nil
         let blockNumber = "0x10"
 
         let expectation = self.expectation(description: "Request should return block number")
         performSuccessfulTask({
             await self.ethereum.getEthBlockNumber()
         }, expectedValue: blockNumber, expectation: expectation)
+        mockReadOnlyRPCProvider.expectation = expectation
         sendResultAndAwait(blockNumber, method: .ethBlockNumber)
         await fulfillment(of: [expectation], timeout: 2.0)
     }
     
     func testGetEthEstimateGas() async {
         ethereum.connected = true
-        ethereum.readOnlyRPCProvider = nil
         let gasEstimate = "0x5208"
 
         let expectation = self.expectation(description: "Request should return gas estimate")
         performSuccessfulTask({
             await self.ethereum.getEthEstimateGas()
         }, expectedValue: gasEstimate, expectation: expectation)
+        mockReadOnlyRPCProvider.expectation = expectation
         sendResultAndAwait(gasEstimate, method: .ethEstimateGas)
         await fulfillment(of: [expectation], timeout: 2.0)
     }
     
     func testGetWeb3ClientVersion() async {
         ethereum.connected = true
-        ethereum.readOnlyRPCProvider = nil
         let web3Version = "Geth/v1.8.23-stable"
 
         let expectation = self.expectation(description: "Request should return web3 version")
         performSuccessfulTask({
             await self.ethereum.getWeb3ClientVersion()
         }, expectedValue: web3Version, expectation: expectation)
+        mockReadOnlyRPCProvider.expectation = expectation
         sendResultAndAwait(web3Version, method: .web3ClientVersion)
         await fulfillment(of: [expectation], timeout: 2.0)
     }
@@ -184,52 +187,54 @@ class EthereumConvenienceMethodsTests: XCTestCase {
     
     func testSendRawTransaction() async {
         ethereum.connected = true
-        ethereum.readOnlyRPCProvider = nil
         let transactionHash = "0x345678"
 
         let expectation = self.expectation(description: "Request should return transaction hash result")
         performSuccessfulTask({
             await self.ethereum.sendRawTransaction(signedTransaction: "signedTx")
         }, expectedValue: transactionHash, expectation: expectation)
+        mockReadOnlyRPCProvider.response = transactionHash
+        mockReadOnlyRPCProvider.expectation = expectation
         sendResultAndAwait(transactionHash, method: .ethSendRawTransaction)
         await fulfillment(of: [expectation], timeout: 2.0)
     }
     
     func testGetBlockTransactionCountByNumber() async {
         ethereum.connected = true
-        ethereum.readOnlyRPCProvider = nil
         let transactionCount = "0x20"
 
         let expectation = self.expectation(description: "Request should return transaction count")
+        mockReadOnlyRPCProvider.response = transactionCount
+        
         performSuccessfulTask({
             await self.ethereum.getBlockTransactionCountByNumber(blockNumber: "0x10")
         }, expectedValue: transactionCount, expectation: expectation)
+        
         sendResultAndAwait(transactionCount, method: .ethGetBlockTransactionCountByNumber)
-        await fulfillment(of: [expectation], timeout: 2.0)
+        await fulfillment(of: [expectation], timeout: 20.0)
     }
     
     func testGetBlockTransactionCountByHash() async {
         ethereum.connected = true
-        ethereum.readOnlyRPCProvider = nil
         let transactionCount = "0x30"
 
         let expectation = self.expectation(description: "Request should return transaction count")
         performSuccessfulTask({
             await self.ethereum.getBlockTransactionCountByHash(blockHash: "0xabcdef")
         }, expectedValue: transactionCount, expectation: expectation)
+        mockReadOnlyRPCProvider.response = transactionCount
+        mockReadOnlyRPCProvider.expectation = expectation
         sendResultAndAwait(transactionCount, method: .ethGetBlockTransactionCountByHash)
         await fulfillment(of: [expectation], timeout: 2.0)
     }
     
     func testGetTransactionCount() async {
         ethereum.connected = true
-        ethereum.readOnlyRPCProvider = nil
         let transactionCount = "0x40"
 
         let expectation = self.expectation(description: "Request should return transaction count")
-        performSuccessfulTask({
-            await self.ethereum.getTransactionCount(address: "0x1234", tagOrblockNumber: "latest")
-        }, expectedValue: transactionCount, expectation: expectation)
+        let result = await self.ethereum.getTransactionCount(address: "0x1234", tagOrblockNumber: "latest")
+        mockReadOnlyRPCProvider.response = transactionCount
         sendResultAndAwait(transactionCount, method: .ethGetTransactionCount)
         await fulfillment(of: [expectation], timeout: 2.0)
     }

--- a/Example/Tests/EthereumTests.swift
+++ b/Example/Tests/EthereumTests.swift
@@ -29,7 +29,10 @@ class EthereumTests: XCTestCase {
         }
         
         mockNetwork = MockNetwork()
-        mockReadOnlyRPCProvider = MockReadOnlyRPCProvider(infuraAPIKey: infuraApiKey, network: mockNetwork)
+        mockReadOnlyRPCProvider = MockReadOnlyRPCProvider(
+            infuraAPIKey: infuraApiKey,
+            readonlyRPCMap: nil,
+            network: mockNetwork)
         mockEthereumDelegate = MockEthereumDelegate()
         EthereumWrapper.shared.ethereum = nil
         SDKWrapper.shared.sdk = nil
@@ -743,7 +746,5 @@ class EthereumTests: XCTestCase {
     
     func testReadOnlyRPCProvider() {
         XCTAssertTrue(ethereum.readOnlyRPCProvider is MockReadOnlyRPCProvider)
-        ethereum.readOnlyRPCProvider = nil
-        XCTAssertNil(ethereum.readOnlyRPCProvider)
     }
 }

--- a/Example/Tests/EthereumTests.swift
+++ b/Example/Tests/EthereumTests.swift
@@ -13,7 +13,7 @@ class EthereumTests: XCTestCase {
     var mockEthereumDelegate: MockEthereumDelegate!
     var trackEventMock: ((Event, [String: Any]) -> Void)!
     var ethereum: Ethereum!
-    var mockInfuraProvider: MockInfuraProvider!
+    var mockReadOnlyRPCProvider: MockReadOnlyRPCProvider!
     let infuraApiKey = "testApiKey"
     var cancellables: Set<AnyCancellable>!
     var trackedEvents: [(Event, [String: Any])] = []
@@ -29,7 +29,7 @@ class EthereumTests: XCTestCase {
         }
         
         mockNetwork = MockNetwork()
-        mockInfuraProvider = MockInfuraProvider(infuraAPIKey: infuraApiKey, network: mockNetwork)
+        mockReadOnlyRPCProvider = MockReadOnlyRPCProvider(infuraAPIKey: infuraApiKey, network: mockNetwork)
         mockEthereumDelegate = MockEthereumDelegate()
         EthereumWrapper.shared.ethereum = nil
         SDKWrapper.shared.sdk = nil
@@ -37,7 +37,7 @@ class EthereumTests: XCTestCase {
             transport: .socket,
             store: store,
             commClientFactory: mockCommClientFactory,
-            infuraProvider: mockInfuraProvider,
+            readOnlyRPCProvider: mockReadOnlyRPCProvider,
             trackEvent: trackEventMock)
         ethereum.delegate = mockEthereumDelegate
     }
@@ -49,7 +49,7 @@ class EthereumTests: XCTestCase {
         ethereum = nil
         mockNetwork = nil
         mockEthereumDelegate = nil
-        mockInfuraProvider = nil
+        mockReadOnlyRPCProvider = nil
         mockCommClientFactory = nil
         EthereumWrapper.shared.ethereum = nil
         SDKWrapper.shared.sdk = nil
@@ -60,11 +60,11 @@ class EthereumTests: XCTestCase {
         let expectation = self.expectation(description: "Read only API call")
         let request = EthereumRequest(method: "eth_blockNumber")
         ethereum.chainId = "0x1"
-        mockInfuraProvider.expectation = expectation
+        mockReadOnlyRPCProvider.expectation = expectation
         ethereum.sendRequest(request)
         
         waitForExpectations(timeout: 2.0) { _ in
-            XCTAssertTrue(self.mockInfuraProvider.sendRequestCalled)
+            XCTAssertTrue(self.mockReadOnlyRPCProvider.sendRequestCalled)
         }
     }
     
@@ -150,15 +150,15 @@ class EthereumTests: XCTestCase {
         waitForExpectations(timeout: 2.0)
     }
     
-    func testSendRequestReadOnlyWithInfuraProvider() {
+    func testSendRequestReadOnlyWithReadOnlyRPCProvider() {
         let expectation = self.expectation(description: "Read-only request with Infura provider")
         let request = EthereumRequest(method: "eth_blockNumber")
-        mockInfuraProvider.expectation = expectation
+        mockReadOnlyRPCProvider.expectation = expectation
         
         ethereum.sendRequest(request)
         
         waitForExpectations(timeout: 2.0) { _ in
-            XCTAssertTrue(self.mockInfuraProvider.sendRequestCalled)
+            XCTAssertTrue(self.mockReadOnlyRPCProvider.sendRequestCalled)
         }
     }
     
@@ -741,9 +741,9 @@ class EthereumTests: XCTestCase {
         XCTAssertFalse(mockEthereumDelegate.accountChangedCalled)
     }
     
-    func testInfuraProvider() {
-        XCTAssertTrue(ethereum.infuraProvider is MockInfuraProvider)
-        ethereum.infuraProvider = nil
-        XCTAssertNil(ethereum.infuraProvider)
+    func testReadOnlyRPCProvider() {
+        XCTAssertTrue(ethereum.readOnlyRPCProvider is MockReadOnlyRPCProvider)
+        ethereum.readOnlyRPCProvider = nil
+        XCTAssertNil(ethereum.readOnlyRPCProvider)
     }
 }

--- a/Example/Tests/InfuraProviderTests.swift
+++ b/Example/Tests/InfuraProviderTests.swift
@@ -1,36 +1,36 @@
 //
-//  InfuraProviderTests.swift
+//  ReadOnlyRPCProviderTests.swift
 //  metamask-ios-sdk_Tests
 //
 
 import XCTest
 @testable import metamask_ios_sdk
 
-class InfuraProviderTests: XCTestCase {
+class ReadOnlyRPCProviderTests: XCTestCase {
 
-    var infuraProvider: InfuraProvider!
+    var readOnlyRPCProvider: ReadOnlyRPCProvider!
     var mockNetwork: MockNetwork!
 
     override func setUp() {
         super.setUp()
         mockNetwork = MockNetwork()
-        infuraProvider = InfuraProvider(infuraAPIKey: "testAPIKey", network: mockNetwork)
+        readOnlyRPCProvider = ReadOnlyRPCProvider(infuraAPIKey: "testAPIKey", readonlyRPCMap: [:], network: mockNetwork)
     }
 
     override func tearDown() {
-        infuraProvider = nil
+        readOnlyRPCProvider = nil
         mockNetwork = nil
         super.tearDown()
     }
 
     func testEndpoint() {
-        let ethereumMainnet = infuraProvider.endpoint(for: "0x1")
+        let ethereumMainnet = readOnlyRPCProvider.endpoint(for: "0x1")
         XCTAssertEqual(ethereumMainnet, "https://mainnet.infura.io/v3/testAPIKey")
 
-        let polygonMainnet = infuraProvider.endpoint(for: "0x89")
+        let polygonMainnet = readOnlyRPCProvider.endpoint(for: "0x89")
         XCTAssertEqual(polygonMainnet, "https://polygon-mainnet.infura.io/v3/testAPIKey")
 
-        let unknownChain = infuraProvider.endpoint(for: "0x999")
+        let unknownChain = readOnlyRPCProvider.endpoint(for: "0x999")
         XCTAssertNil(unknownChain)
     }
 
@@ -48,7 +48,7 @@ class InfuraProviderTests: XCTestCase {
         let request = EthereumRequest(id: "1", method: "eth_chainId")
         let appMetadata = AppMetadata(name: "TestApp", url: "https://testapp.com")
 
-        let result = await infuraProvider.sendRequest(request, chainId: "0x1", appMetadata: appMetadata)
+        let result = await readOnlyRPCProvider.sendRequest(request, chainId: "0x1", appMetadata: appMetadata)
 
         XCTAssertEqual(result as? String, "0x1")
     }
@@ -57,7 +57,7 @@ class InfuraProviderTests: XCTestCase {
         let request = EthereumRequest(id: "1", method: "eth_chainId")
         let appMetadata = AppMetadata(name: "TestApp", url: "https://testapp.com")
 
-        let result = await infuraProvider.sendRequest(request, chainId: "0x999", appMetadata: appMetadata)
+        let result = await readOnlyRPCProvider.sendRequest(request, chainId: "0x999", appMetadata: appMetadata)
 
         XCTAssertNil(result)
     }
@@ -68,7 +68,7 @@ class InfuraProviderTests: XCTestCase {
         let request = EthereumRequest(id: "1", method: "eth_chainId")
         let appMetadata = AppMetadata(name: "TestApp", url: "https://testapp.com")
 
-        let result = await infuraProvider.sendRequest(request, chainId: "0x1", appMetadata: appMetadata)
+        let result = await readOnlyRPCProvider.sendRequest(request, chainId: "0x1", appMetadata: appMetadata)
 
         XCTAssertNil(result)
     }

--- a/Example/Tests/MockInfuraProvider.swift
+++ b/Example/Tests/MockInfuraProvider.swift
@@ -1,12 +1,12 @@
 //
-//  MockInfuraProvider.swift
+//  MockReadOnlyRPCProvider.swift
 //  metamask-ios-sdk_Tests
 //
 
 @testable import metamask_ios_sdk
 import XCTest
 
-class MockInfuraProvider: InfuraProvider {
+class MockReadOnlyRPCProvider: ReadOnlyRPCProvider {
     var sendRequestCalled = false
     var response: Any? = "{}"
     var expectation: XCTestExpectation?

--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ func application(_ app: UIApplication, open url: URL, options: [UIApplication.Op
     return true
 }
 ```
-And then initialise the SDK, specifying `.deeplinking` as the transport type, passing the dapp's' scheme you added in the URL Types as the `dappScheme`.
+And then initialise the SDK, specifying `.deeplinking` as the transport type, passing the dapp's' scheme you added in the URL Types as the `dappScheme`. To use the Infura API to make read-only requests, specify your Infura API key using the `infuraAPIKey` option in `SDKOptions`. To use your own node (for example, with Hardhat) to make read-only requests, specify your node's chain ID and RPC URL using the readonlyRPCMap option.
 ```swift
 @ObservedObject var metamaskSDK = MetaMaskSDK.shared(
     appMetadata,
     transport: .deeplinking(dappScheme: "dubdapp"),
-    sdkOptions: SDKOptions(infuraAPIKey: "your-api-key") // for read-only RPC calls
+    sdkOptions: SDKOptions(infuraAPIKey: "your-api-key", readonlyRPCMap: ["0x1": "hptts://www.testrpc.com"]) // for read-only RPC calls
 )
 ```
 #### NOTE

--- a/Sources/metamask-ios-sdk/Classes/API/InfuraProvider.swift
+++ b/Sources/metamask-ios-sdk/Classes/API/InfuraProvider.swift
@@ -1,79 +1,106 @@
 //
-//  InfuraProvider.swift
+//  ReadOnlyRPCProvider.swift
 //  metamask-ios-sdk
 //
 
 import Foundation
 
-public class InfuraProvider {
-    private let infuraAPIKey: String
+public class ReadOnlyRPCProvider {
+    let infuraAPIKey: String
     private let network: any Networking
-
-    public init(infuraAPIKey: String, network: any Networking = Network()) {
-        self.infuraAPIKey = infuraAPIKey
-        self.network = network
+    
+    let readonlyRPCMap: [String: String]
+    
+    public convenience init(infuraAPIKey: String? = nil, readonlyRPCMap: [String: String]? = nil) {
+        self.init(infuraAPIKey: infuraAPIKey, readonlyRPCMap: readonlyRPCMap, network: Network())
     }
 
+    init(infuraAPIKey: String? = nil, readonlyRPCMap: [String: String]?, network: any Networking) {
+        self.infuraAPIKey = infuraAPIKey ?? ""
+        self.network = network
+        
+        if let providedRPCMap = readonlyRPCMap {
+            if let apiKey = infuraAPIKey {
+                // Merge infuraReadonlyRPCMap with readonlyRPCMap, overriding infura's keys if they are present in readonlyRPCMap
+                var mergedMap = ReadOnlyRPCProvider.infuraReadonlyRPCMap(apiKey)
+                providedRPCMap.forEach { mergedMap[$0.key] = $0.value }
+                self.readonlyRPCMap = mergedMap
+            } else {
+                // Use only the provided readonlyRPCMap
+                self.readonlyRPCMap = providedRPCMap
+            }
+        } else if let apiKey = infuraAPIKey {
+            // Use infuraReadonlyRPCMap as default
+            self.readonlyRPCMap = ReadOnlyRPCProvider.infuraReadonlyRPCMap(apiKey)
+        } else {
+            // Default to an empty map if neither are provided
+            self.readonlyRPCMap = [:]
+        }
+    }
+    
+    static func infuraReadonlyRPCMap(_ infuraAPIKey: String) -> [String: String] {
+        [
+            // ###### Ethereum ######
+            // Mainnet
+            "0x1": "https://mainnet.infura.io/v3/\(infuraAPIKey)",
+            // Sepolia 11155111
+            "0x2a": "https://sepolia.infura.io/v3/\(infuraAPIKey)",
+            // ###### Polygon ######
+            // Mainnet
+            "0x89": "https://polygon-mainnet.infura.io/v3/\(infuraAPIKey)",
+            // Mumbai
+            "0x13881": "https://polygon-mumbai.infura.io/v3/\(infuraAPIKey)",
+            // ###### Optimism ######
+            // Mainnet
+            "0x45": "https://optimism-mainnet.infura.io/v3/\(infuraAPIKey)",
+            // Goerli
+            "0x1a4": "https://optimism-goerli.infura.io/v3/\(infuraAPIKey)",
+            // ###### Arbitrum ######
+            // Mainnet
+            "0xa4b1": "https://arbitrum-mainnet.infura.io/v3/\(infuraAPIKey)",
+            // Goerli
+            "0x66eed": "https://arbitrum-goerli.infura.io/v3/\(infuraAPIKey)",
+            // ###### Palm ######
+            // Mainnet
+            "0x2a15c308d": "https://palm-mainnet.infura.io/v3/\(infuraAPIKey)",
+            // Testnet
+            "0x2a15c3083": "https://palm-testnet.infura.io/v3/\(infuraAPIKey)",
+            // ###### Avalanche C-Chain ######
+            // Mainnet
+            "0xa86a": "https://avalanche-mainnet.infura.io/v3/\(infuraAPIKey)",
+            // Fuji
+            "0xa869": "https://avalanche-fuji.infura.io/v3/\(infuraAPIKey)",
+            // ###### NEAR ######
+            // // Mainnet
+            // "0x4e454152": "https://near-mainnet.infura.io/v3/\(infuraAPIKey)",
+            // // Testnet
+            // "0x4e454153": "https://near-testnet.infura.io/v3/\(infuraAPIKey)",
+            // ###### Aurora ######
+            // Mainnet
+            "0x4e454152": "https://aurora-mainnet.infura.io/v3/\(infuraAPIKey)",
+            // Testnet
+            "0x4e454153": "https://aurora-testnet.infura.io/v3/\(infuraAPIKey)",
+            // ###### StarkNet ######
+            // Mainnet
+            "0x534e5f4d41494e": "https://starknet-mainnet.infura.io/v3/\(infuraAPIKey)",
+            // Goerli
+            "0x534e5f474f45524c49": "https://starknet-goerli.infura.io/v3/\(infuraAPIKey)",
+            // Goerli 2
+            "0x534e5f474f45524c4932": "https://starknet-goerli2.infura.io/v3/\(infuraAPIKey)",
+            // ###### Celo ######
+            // Mainnet
+            "0xa4ec": "https://celo-mainnet.infura.io/v3/\(infuraAPIKey)",
+            // Alfajores Testnet
+            "0xaef3": "https://celo-alfajores.infura.io/v3/\(infuraAPIKey)"
+        ]
+    }
+    
     func endpoint(for chainId: String) -> String? {
-        let rpcUrls: [String: String] = [
-                // ###### Ethereum ######
-                // Mainnet
-                "0x1": "https://mainnet.infura.io/v3/\(infuraAPIKey)",
-                // Sepolia 11155111
-                "0x2a": "https://sepolia.infura.io/v3/\(infuraAPIKey)",
-                // ###### Polygon ######
-                // Mainnet
-                "0x89": "https://polygon-mainnet.infura.io/v3/\(infuraAPIKey)",
-                // Mumbai
-                "0x13881": "https://polygon-mumbai.infura.io/v3/\(infuraAPIKey)",
-                // ###### Optimism ######
-                // Mainnet
-                "0x45": "https://optimism-mainnet.infura.io/v3/\(infuraAPIKey)",
-                // Goerli
-                "0x1a4": "https://optimism-goerli.infura.io/v3/\(infuraAPIKey)",
-                // ###### Arbitrum ######
-                // Mainnet
-                "0xa4b1": "https://arbitrum-mainnet.infura.io/v3/\(infuraAPIKey)",
-                // Goerli
-                "0x66eed": "https://arbitrum-goerli.infura.io/v3/\(infuraAPIKey)",
-                // ###### Palm ######
-                // Mainnet
-                "0x2a15c308d": "https://palm-mainnet.infura.io/v3/\(infuraAPIKey)",
-                // Testnet
-                "0x2a15c3083": "https://palm-testnet.infura.io/v3/\(infuraAPIKey)",
-                // ###### Avalanche C-Chain ######
-                // Mainnet
-                "0xa86a": "https://avalanche-mainnet.infura.io/v3/\(infuraAPIKey)",
-                // Fuji
-                "0xa869": "https://avalanche-fuji.infura.io/v3/\(infuraAPIKey)",
-                // ###### NEAR ######
-                // // Mainnet
-                // "0x4e454152": "https://near-mainnet.infura.io/v3/\(infuraAPIKey)",
-                // // Testnet
-                // "0x4e454153": "https://near-testnet.infura.io/v3/\(infuraAPIKey)",
-                // ###### Aurora ######
-                // Mainnet
-                "0x4e454152": "https://aurora-mainnet.infura.io/v3/\(infuraAPIKey)",
-                // Testnet
-                "0x4e454153": "https://aurora-testnet.infura.io/v3/\(infuraAPIKey)",
-                // ###### StarkNet ######
-                // Mainnet
-                "0x534e5f4d41494e": "https://starknet-mainnet.infura.io/v3/\(infuraAPIKey)",
-                // Goerli
-                "0x534e5f474f45524c49": "https://starknet-goerli.infura.io/v3/\(infuraAPIKey)",
-                // Goerli 2
-                "0x534e5f474f45524c4932": "https://starknet-goerli2.infura.io/v3/\(infuraAPIKey)",
-                // ###### Celo ######
-                // Mainnet
-                "0xa4ec": "https://celo-mainnet.infura.io/v3/\(infuraAPIKey)",
-                // Alfajores Testnet
-                "0xaef3": "https://celo-alfajores.infura.io/v3/\(infuraAPIKey)"
-            ]
-        return rpcUrls[chainId]
+        readonlyRPCMap[chainId]
     }
 
     public func sendRequest(_ request: any RPCRequest, chainId: String, appMetadata: AppMetadata) async -> Any? {
-        Logging.log("InfuraProvider:: Sending request \(request.method) on chain \(chainId) via Infura API")
+        Logging.log("ReadOnlyRPCProvider:: Sending request \(request.method) on chain \(chainId) via Infura API")
 
         let params: [String: Any] = [
             "method": request.method,
@@ -83,7 +110,7 @@ public class InfuraProvider {
         ]
 
         guard let endpoint = endpoint(for: chainId) else {
-            Logging.error("InfuraProvider:: Infura endpoint for chainId \(chainId) is not available")
+            Logging.error("ReadOnlyRPCProvider:: Infura endpoint for chainId \(chainId) is not available")
             return nil
         }
 
@@ -104,7 +131,7 @@ public class InfuraProvider {
                 return result
             }
 
-            Logging.error("InfuraProvider:: could not get result from response \(json)")
+            Logging.error("ReadOnlyRPCProvider:: could not get result from response \(json)")
             return nil
         } catch {
             Logging.error("tracking error: \(error.localizedDescription)")

--- a/Sources/metamask-ios-sdk/Classes/SDK/Dependencies.swift
+++ b/Sources/metamask-ios-sdk/Classes/SDK/Dependencies.swift
@@ -15,11 +15,13 @@ public final class Dependencies {
     
     public lazy var commClientFactory: CommClientFactory = CommClientFactory()
 
-    public func ethereum(transport: Transport) -> Ethereum {
+    public func ethereum(transport: Transport, sdkOptions: SDKOptions?) -> Ethereum {
         Ethereum.shared(
             transport: transport,
             store: store,
-            commClientFactory: commClientFactory) { event, parameters in
+            commClientFactory: commClientFactory,
+            readOnlyRPCProvider: ReadOnlyRPCProvider(infuraAPIKey: sdkOptions?.infuraAPIKey, readonlyRPCMap: sdkOptions?.readonlyRPCMap)
+        ) { event, parameters in
             self.trackEvent(event, parameters: parameters)
         }.updateTransportLayer(transport)
     }

--- a/Sources/metamask-ios-sdk/Classes/SDK/MetaMaskSDK.swift
+++ b/Sources/metamask-ios-sdk/Classes/SDK/MetaMaskSDK.swift
@@ -58,10 +58,9 @@ public class MetaMaskSDK: ObservableObject {
     }
 
     private init(appMetadata: AppMetadata, transport: Transport, enableDebug: Bool, sdkOptions: SDKOptions?) {
-        self.ethereum = Dependencies.shared.ethereum(transport: transport)
+        self.ethereum = Dependencies.shared.ethereum(transport: transport, sdkOptions: sdkOptions)
         self.transport = transport
         self.ethereum.delegate = self
-        self.ethereum.sdkOptions = sdkOptions
         self.ethereum.updateMetadata(appMetadata)
         self.tracker.enableDebug = enableDebug
         self.account = ethereum.account

--- a/Sources/metamask-ios-sdk/Classes/SDK/SDKOptions.swift
+++ b/Sources/metamask-ios-sdk/Classes/SDK/SDKOptions.swift
@@ -7,8 +7,10 @@ import Foundation
 
 public struct SDKOptions {
     public let infuraAPIKey: String
+    public let readonlyRPCMap: [String: String]
 
-    public init(infuraAPIKey: String) {
+    public init(infuraAPIKey: String, readonlyRPCMap: [String: String] = [:]) {
         self.infuraAPIKey = infuraAPIKey
+        self.readonlyRPCMap = readonlyRPCMap
     }
 }


### PR DESCRIPTION
This PR adds the ability to use both the Infura API and custom nodes to make read-only requests by specifying both the [infuraAPIKey](https://docs.metamask.io/wallet/reference/sdk-js-options/#infuraapikey) and [readonlyRPCMap](https://docs.metamask.io/wallet/reference/sdk-js-options/#readonlyrpcmap) options when instantiating the SDK in the dapp. It previously only supported the Infura API but not custom nodes.