### PR TITLE
fix: return an array of accounts on connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Alternatively, you can add the URL directly in your project's package file:
 dependencies: [
     .package(
         url: "https://github.com/MetaMask/metamask-ios-sdk",
-        from: "0.8.1"
+        from: "0.8.6"
     )
 ]
 ```

--- a/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
+++ b/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
@@ -198,8 +198,8 @@ public class Ethereum {
     }
     
     @discardableResult
-    func connect() async -> Result<String, RequestError> {
-        await performAsyncOperation(connect(), defaultValue: String()) as Result<String, RequestError>
+    func connect() async -> Result<[String], RequestError> {
+        await performAsyncOperation(connect(), defaultValue: []) as Result<[String], RequestError>
     }
 
     func connectAndSign(message: String) -> EthereumPublisher? {
@@ -811,7 +811,7 @@ public class Ethereum {
                 let accounts = event["accounts"] as? [String],
                 let selectedAddress = accounts.first {
                 updateAccount(selectedAddress)
-                sendResult(selectedAddress, id: Ethereum.CONNECTION_ID)
+                sendResult(accounts, id: Ethereum.CONNECTION_ID)
             }
             return
         }

--- a/Sources/metamask-ios-sdk/Classes/SDK/MetaMaskSDK.swift
+++ b/Sources/metamask-ios-sdk/Classes/SDK/MetaMaskSDK.swift
@@ -102,7 +102,7 @@ public class MetaMaskSDK: ObservableObject {
 }
 
 public extension MetaMaskSDK {
-    func connect() async -> Result<String, RequestError> {
+    func connect() async -> Result<[String], RequestError> {
         await ethereum.connect()
     }
 

--- a/metamask-ios-sdk.podspec
+++ b/metamask-ios-sdk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'metamask-ios-sdk'
-  s.version          = '0.8.5'
+  s.version          = '0.8.6'
   s.summary          = 'Enable users to easily connect with their MetaMask Mobile wallet.'
   s.swift_version    = '5.5'
 


### PR DESCRIPTION
Presently the SDK returns the selected address as the result of connect instead of an array of accounts - which is the response for `eth_requestAccounts`