### PR TITLE
fix: handling rn sdk read-only calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Alternatively, you can add the URL directly in your project's package file:
 dependencies: [
     .package(
         url: "https://github.com/MetaMask/metamask-ios-sdk",
-        from: "0.8.6"
+        from: "0.8.7"
     )
 ]
 ```

--- a/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
+++ b/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
@@ -431,17 +431,13 @@ public class Ethereum {
         submittedRequests.removeAll()
         clearSession()
     }
-    
-    func useReadOnlyRPCProvider() -> Bool {
-        !readOnlyRPCProvider.infuraAPIKey.isEmpty || !readOnlyRPCProvider.readonlyRPCMap.isEmpty
-    }
 
     // MARK: Request Sending
 
     func sendRequest(_ request: any RPCRequest) {
         if
             EthereumMethod.isReadOnly(request.methodType),
-            useReadOnlyRPCProvider() {
+            readOnlyRPCProvider.supportsChain(chainId) {
             Task {
                 let readOnlyRequest = EthereumRequest(
                     id: request.id,

--- a/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
+++ b/Sources/metamask-ios-sdk/Classes/Ethereum/Ethereum.swift
@@ -443,8 +443,21 @@ public class Ethereum {
             EthereumMethod.isReadOnly(request.methodType),
             useReadOnlyRPCProvider() {
             Task {
+                let readOnlyRequest = EthereumRequest(
+                    id: request.id,
+                    method: request.method
+                )
+                var params: Any = request.params
+                
+                if
+                    let paramsData = request.params as? Data,
+                    let json = try? JSONSerialization.jsonObject(with: paramsData, options: []) {
+                    params = json
+                }
+                
                 if let result = await readOnlyRPCProvider.sendRequest(
-                    request,
+                    readOnlyRequest,
+                    params: params,
                     chainId: chainId,
                     appMetadata: commClient.appMetadata ?? AppMetadata(name: "", url: "")) {
                     sendResult(result, id: request.id)

--- a/metamask-ios-sdk.podspec
+++ b/metamask-ios-sdk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'metamask-ios-sdk'
-  s.version          = '0.8.6'
+  s.version          = '0.8.7'
   s.summary          = 'Enable users to easily connect with their MetaMask Mobile wallet.'
   s.swift_version    = '5.5'
 


### PR DESCRIPTION
This PR improves handling of read only API calls via Infura coming from the RN SDK. Because the requests from RN are sent as `Data`, they are converted to JSON on the iOS SDK and sent to wallet in that manner and sanitised on the wallet. However, for the read-only RPCs via Infura, these are sent via `Network` and not sanitised accordingly and resulted in a crash.

Addresses issue reported in [Testing Integration Issue with Aarna Builder ](https://github.com/MetaMask/metamask-sdk/pull/1018) 