### PR TITLE
chore: change commlayer to deeplink

### DIFF
--- a/Sources/metamask-ios-sdk/Classes/CommunicationLayer/DeeplinkCommLayer/DeeplinkClient.swift
+++ b/Sources/metamask-ios-sdk/Classes/CommunicationLayer/DeeplinkCommLayer/DeeplinkClient.swift
@@ -111,7 +111,7 @@ public class DeeplinkClient: CommClient {
     public func track(event: Event) {
         let parameters: [String: Any] = [
             "id": channelId,
-            "commLayer": "socket",
+            "commLayer": "deeplink",
             "sdkVersion": SDKInfo.version,
             "url": appMetadata?.url ?? "",
             "dappId": SDKInfo.bundleIdentifier ?? "N/A",

--- a/Sources/metamask-ios-sdk/Classes/CommunicationLayer/DeeplinkCommLayer/DeeplinkClient.swift
+++ b/Sources/metamask-ios-sdk/Classes/CommunicationLayer/DeeplinkCommLayer/DeeplinkClient.swift
@@ -111,7 +111,7 @@ public class DeeplinkClient: CommClient {
     public func track(event: Event) {
         let parameters: [String: Any] = [
             "id": channelId,
-            "commLayer": "deeplink",
+            "commLayer": "deeplinking",
             "sdkVersion": SDKInfo.version,
             "url": appMetadata?.url ?? "",
             "dappId": SDKInfo.bundleIdentifier ?? "N/A",


### PR DESCRIPTION
This PR changes `commLayer` to `deeplinking_` when the communication layer is deeplinking