### PR TITLE
fix: multithreading handling

### DIFF
--- a/Example/Tests/MockInfuraProvider.swift
+++ b/Example/Tests/MockInfuraProvider.swift
@@ -11,7 +11,10 @@ class MockReadOnlyRPCProvider: ReadOnlyRPCProvider {
     var response: Any? = "{}"
     var expectation: XCTestExpectation?
     
-    override func sendRequest(_ request: any RPCRequest, chainId: String, appMetadata: AppMetadata) async -> Any? {
+    override func sendRequest(_ request: any RPCRequest,
+                              params: Any = "",
+                              chainId: String,
+                              appMetadata: AppMetadata) async -> Any? {
         sendRequestCalled = true
         expectation?.fulfill()
         return response

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Alternatively, you can add the URL directly in your project's package file:
 dependencies: [
     .package(
         url: "https://github.com/MetaMask/metamask-ios-sdk",
-        from: "0.8.7"
+        from: "0.8.8"
     )
 ]
 ```

--- a/Sources/metamask-ios-sdk/Classes/API/InfuraProvider.swift
+++ b/Sources/metamask-ios-sdk/Classes/API/InfuraProvider.swift
@@ -109,7 +109,6 @@ public class ReadOnlyRPCProvider {
                             params: Any = "",
                             chainId: String,
                             appMetadata: AppMetadata) async -> Any? {
-        Logging.log("ReadOnlyRPCProvider:: Sending request \(request.method) on chain \(chainId) via Infura API")
 
         let params: [String: Any] = [
             "method": request.method,
@@ -122,6 +121,8 @@ public class ReadOnlyRPCProvider {
             Logging.error("ReadOnlyRPCProvider:: Infura endpoint for chainId \(chainId) is not available")
             return nil
         }
+        
+        Logging.log("ReadOnlyRPCProvider:: Sending request \(request.method) on chain \(chainId) using endpoint \(endpoint) via Infura API")
 
         let devicePlatformInfo = DeviceInfo.platformDescription
         network.addHeaders([

--- a/Sources/metamask-ios-sdk/Classes/Analytics/Event.swift
+++ b/Sources/metamask-ios-sdk/Classes/Analytics/Event.swift
@@ -11,6 +11,7 @@ public enum Event: String {
     case connectionAuthorised = "sdk_connection_authorized"
     case connectionRejected = "sdk_connection_rejected"
     case disconnected = "sdk_disconnected"
+    case connectionTerminated = "sdk_connection_terminated"
 
     var name: String {
         rawValue

--- a/Sources/metamask-ios-sdk/Classes/Extensions/NSRecursiveLock.swift
+++ b/Sources/metamask-ios-sdk/Classes/Extensions/NSRecursiveLock.swift
@@ -1,0 +1,14 @@
+//
+//  NSRecursiveLock.swift
+//
+
+import Foundation
+
+extension NSRecursiveLock {
+  @inlinable @discardableResult
+  func sync<Value>(_ work: () -> Value) -> Value {
+    lock()
+    defer { unlock() }
+    return work()
+  }
+}

--- a/metamask-ios-sdk.podspec
+++ b/metamask-ios-sdk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'metamask-ios-sdk'
-  s.version          = '0.8.7'
+  s.version          = '0.8.8'
   s.summary          = 'Enable users to easily connect with their MetaMask Mobile wallet.'
   s.swift_version    = '5.5'
 


### PR DESCRIPTION
This PR adds ability for the SDK to handle multiple threads by accessing shared resources via a lock. Currently when more than one provider is accessing the code, it runs into race conditions.